### PR TITLE
Feature: Map managers

### DIFF
--- a/src/components/game/index.jsx
+++ b/src/components/game/index.jsx
@@ -94,7 +94,7 @@ class GameScreen extends React.Component {
         <canvas ref="canvas"></canvas>
         <HUD />
         <Controls ref="controls" for={ session.player } camera={ this.camera } />
-        <Stats ref="stats" renderer={ this.renderer } />
+        <Stats ref="stats" renderer={ this.renderer } map={ session.world.map } />
       </game>
     );
   }

--- a/src/components/game/stats/index.jsx
+++ b/src/components/game/stats/index.jsx
@@ -9,6 +9,59 @@ class Stats extends React.Component {
     map: React.PropTypes.object
   };
 
+  mapStats() {
+    const map = this.props.map;
+
+    return (
+      <div>
+        <div className="divider"></div>
+
+        <h2>Map Chunks</h2>
+        <div className="divider"></div>
+        <p>
+          Loaded: { map ? map.chunks.size : 0 }
+        </p>
+
+        <div className="divider"></div>
+
+        <h2>Map Doodads</h2>
+        <div className="divider"></div>
+        <p>
+          Loading: { map ? map.doodadManager.entriesPendingLoad.size : 0 }
+        </p>
+        <p>
+          Loaded: { map ? map.doodadManager.doodads.size : 0 }
+        </p>
+        <p>
+          Animated: { map ? map.doodadManager.animatedDoodads.size : 0 }
+        </p>
+
+        <div className="divider"></div>
+
+        <h2>WMOs</h2>
+        <div className="divider"></div>
+        <p>
+          Loading Roots: { map ? map.wmoManager.entriesPendingLoad.size : 0 }
+        </p>
+        <p>
+          Loaded Roots: { map ? map.wmoManager.wmos.size : 0 }
+        </p>
+        <p>
+          Loading Groups: { map ? map.wmoManager.groupsPendingLoadCount : 0 }
+        </p>
+        <p>
+          Loaded Groups: { map ? map.wmoManager.groupCount : 0 }
+        </p>
+        <p>
+          Loading Doodads: { map ? map.wmoManager.doodadsPendingLoadCount : 0 }
+        </p>
+        <p>
+          Loaded Doodads: { map ? map.wmoManager.doodadCount : 0 }
+        </p>
+      </div>
+    );
+  }
+
   render() {
     const renderer = this.props.renderer;
     if (!renderer) {
@@ -49,42 +102,7 @@ class Stats extends React.Component {
           Vertices: { render.vertices }
         </p>
 
-        <div className="divider"></div>
-
-        <h2>Map Doodads</h2>
-        <div className="divider"></div>
-        <p>
-          Loading: { map ? map.doodadManager.entriesPendingLoad.size : 0 }
-        </p>
-        <p>
-          Loaded: { map ? map.doodadManager.doodads.size : 0 }
-        </p>
-        <p>
-          Animated: { map ? map.doodadManager.animatedDoodads.size : 0 }
-        </p>
-
-        <div className="divider"></div>
-
-        <h2>WMOs</h2>
-        <div className="divider"></div>
-        <p>
-          Loading Roots: { map ? map.wmoManager.entriesPendingLoad.size : 0 }
-        </p>
-        <p>
-          Loaded Roots: { map ? map.wmoManager.wmos.size : 0 }
-        </p>
-        <p>
-          Loading Groups: { map ? map.wmoManager.groupsPendingLoadCount : 0 }
-        </p>
-        <p>
-          Loaded Groups: { map ? map.wmoManager.groupCount : 0 }
-        </p>
-        <p>
-          Loading Doodads: { map ? map.wmoManager.doodadsPendingLoadCount : 0 }
-        </p>
-        <p>
-          Loaded Doodads: { map ? map.wmoManager.doodadCount : 0 }
-        </p>
+        { map && this.mapStats() }
       </stats>
     );
   }

--- a/src/components/game/stats/index.jsx
+++ b/src/components/game/stats/index.jsx
@@ -5,7 +5,8 @@ import './index.styl';
 class Stats extends React.Component {
 
   static propTypes = {
-    renderer: React.PropTypes.object
+    renderer: React.PropTypes.object,
+    map: React.PropTypes.object
   };
 
   render() {
@@ -13,6 +14,8 @@ class Stats extends React.Component {
     if (!renderer) {
       return null;
     }
+
+    const map = this.props.map;
 
     const { memory, programs, render } = renderer.info;
     return (
@@ -44,6 +47,43 @@ class Stats extends React.Component {
         </p>
         <p>
           Vertices: { render.vertices }
+        </p>
+
+        <div className="divider"></div>
+
+        <h2>Map Doodads</h2>
+        <div className="divider"></div>
+        <p>
+          Loading: { map ? map.doodadManager.entriesPendingLoad.size : 0 }
+        </p>
+        <p>
+          Loaded: { map ? map.doodadManager.doodads.size : 0 }
+        </p>
+        <p>
+          Animated: { map ? map.doodadManager.animatedDoodads.size : 0 }
+        </p>
+
+        <div className="divider"></div>
+
+        <h2>WMOs</h2>
+        <div className="divider"></div>
+        <p>
+          Loading Roots: { map ? map.wmoManager.entriesPendingLoad.size : 0 }
+        </p>
+        <p>
+          Loaded Roots: { map ? map.wmoManager.wmos.size : 0 }
+        </p>
+        <p>
+          Loading Groups: { map ? map.wmoManager.groupsPendingLoadCount : 0 }
+        </p>
+        <p>
+          Loaded Groups: { map ? map.wmoManager.groupCount : 0 }
+        </p>
+        <p>
+          Loading Doodads: { map ? map.wmoManager.doodadsPendingLoadCount : 0 }
+        </p>
+        <p>
+          Loaded Doodads: { map ? map.wmoManager.doodadCount : 0 }
         </p>
       </stats>
     );

--- a/src/components/game/stats/index.styl
+++ b/src/components/game/stats/index.styl
@@ -3,4 +3,4 @@ wowser .stats
   bottom: 0
   right: 0
   z-index: 3
-  width: 140px
+  width: 160px

--- a/src/lib/game/unit.js
+++ b/src/lib/game/unit.js
@@ -2,7 +2,7 @@ import THREE from 'three';
 
 import DBC from '../pipeline/dbc';
 import Entity from './entity';
-import M2 from '../pipeline/m2';
+import M2Blueprint from '../pipeline/m2/blueprint';
 
 class Unit extends Entity {
 
@@ -51,7 +51,7 @@ class Unit extends Entity {
         this.modelData.path = this.modelData.file.match(/^(.+?)(?:[^\\]+)$/)[1];
         this.displayInfo.modelData = this.modelData;
 
-        M2.load(this.modelData.file).then((m2) => {
+        M2Blueprint.load(this.modelData.file).then((m2) => {
           m2.displayInfo = this.displayInfo;
           this.model = m2;
         });

--- a/src/lib/game/unit.js
+++ b/src/lib/game/unit.js
@@ -75,6 +75,7 @@ class Unit extends Entity {
 
     // TODO: Figure out whether this 180 degree rotation is correct
     m2.rotation.z = Math.PI;
+    m2.updateMatrix();
 
     this.view.add(m2);
 

--- a/src/lib/game/world/doodad-manager.js
+++ b/src/lib/game/world/doodad-manager.js
@@ -3,7 +3,6 @@ import M2 from '../../pipeline/m2';
 class DoodadManager {
 
   // Proportion of pending doodads to load or unload in a given tick.
-  // Ex: 1 / 15 aims to have all currently pending doodads loaded within a quarter second.
   static LOAD_FACTOR = 1 / 15;
 
   // Number of milliseconds to wait before loading another portion of doodads.

--- a/src/lib/game/world/doodad-manager.js
+++ b/src/lib/game/world/doodad-manager.js
@@ -2,13 +2,9 @@ import M2 from '../../pipeline/m2';
 
 class DoodadManager {
 
-  // Radius in chunks for which doodads should appear.
-  // TODO: Even worth the bother to implement this?
-  static VISIBILITY_RADIUS = 12;
-
   // Proportion of pending doodads to load or unload in a given tick.
-  // Ex: 1 / 30 aims to have all currently pending doodads loaded within a half second.
-  static LOAD_FACTOR = 1 / 30;
+  // Ex: 1 / 15 aims to have all currently pending doodads loaded within a quarter second.
+  static LOAD_FACTOR = 1 / 15;
 
   // Number of milliseconds to wait before loading another portion of doodads.
   static LOAD_INTERVAL = (1 / 60) * 1000;
@@ -16,12 +12,6 @@ class DoodadManager {
   constructor(map) {
     this.map = map;
     this.chunkRefs = new Map();
-
-    this.chunkX = null;
-    this.chunkY = null;
-
-    this.visibleChunks = [];
-    this.visibleDoodadCount = 0;
 
     this.doodads = new Map();
     this.animatedDoodads = new Map();
@@ -34,23 +24,8 @@ class DoodadManager {
     this.loadDoodads = ::this.loadDoodads;
     this.unloadDoodads = ::this.unloadDoodads;
 
-    setInterval(this.loadDoodads, 1);
-    setInterval(this.unloadDoodads, 1);
-  }
-
-  updateCurrentChunk(chunkX, chunkY) {
-    this.chunkX = chunkX;
-    this.chunkY = chunkY;
-
-    this.calculateVisibleChunks();
-  }
-
-  calculateVisibleChunks() {
-    this.visibleChunks = this.map.chunkIndicesAround(
-      this.chunkX,
-      this.chunkY,
-      this.constructor.VISIBILITY_RADIUS
-    );
+    setInterval(this.loadDoodads, this.constructor.LOAD_INTERVAL);
+    setInterval(this.unloadDoodads, this.constructor.LOAD_INTERVAL);
   }
 
   // Process a set of doodad entries for a given chunk index of the world map.
@@ -141,12 +116,12 @@ class DoodadManager {
       this.placeDoodad(doodad, entry.position, entry.rotation, entry.scale);
 
       if (doodad.animated) {
-        this.animateDoodad(entry, doodad);
+        this.enableDoodadAnimations(entry, doodad);
       }
     });
   }
 
-  animateDoodad(entry, doodad) {
+  enableDoodadAnimations(entry, doodad) {
     // Maintain separate entries for animated doodads to avoid excessive iterations on each
     // call to animate() during the render loop.
     this.animatedDoodads.set(entry.id, doodad);

--- a/src/lib/game/world/doodad-manager.js
+++ b/src/lib/game/world/doodad-manager.js
@@ -1,0 +1,242 @@
+import M2 from '../../pipeline/m2';
+
+class DoodadManager {
+
+  // Radius in chunks for which doodads should appear.
+  // TODO: Even worth the bother to implement this?
+  static VISIBILITY_RADIUS = 12;
+
+  // Proportion of pending doodads to load or unload in a given tick.
+  // Ex: 1 / 30 aims to have all currently pending doodads loaded within a half second.
+  static LOAD_FACTOR = 1 / 30;
+
+  // Number of milliseconds to wait before loading another portion of doodads.
+  static LOAD_INTERVAL = (1 / 60) * 1000;
+
+  constructor(map) {
+    this.map = map;
+    this.chunkRefs = new Map();
+
+    this.chunkX = null;
+    this.chunkY = null;
+
+    this.visibleChunks = [];
+    this.visibleDoodadCount = 0;
+
+    this.doodads = new Map();
+    this.animatedDoodads = new Map();
+
+    this.entriesPendingLoad = new Map();
+    this.entriesPendingUnload = new Map();
+
+    this.loadChunk = ::this.loadChunk;
+    this.unloadChunk = ::this.unloadChunk;
+    this.loadDoodads = ::this.loadDoodads;
+    this.unloadDoodads = ::this.unloadDoodads;
+
+    setInterval(this.loadDoodads, 1);
+    setInterval(this.unloadDoodads, 1);
+  }
+
+  updateCurrentChunk(chunkX, chunkY) {
+    this.chunkX = chunkX;
+    this.chunkY = chunkY;
+
+    this.calculateVisibleChunks();
+  }
+
+  calculateVisibleChunks() {
+    this.visibleChunks = this.map.chunkIndicesAround(
+      this.chunkX,
+      this.chunkY,
+      this.constructor.VISIBILITY_RADIUS
+    );
+  }
+
+  // Process a set of doodad entries for a given chunk index of the world map.
+  loadChunk(index, entries) {
+    for (let i = 0, len = entries.length; i < len; ++i) {
+      const entry = entries[i];
+
+      let chunkRefs;
+
+      // Fetch or create chunk references for entry.
+      if (this.chunkRefs.has(entry.id)) {
+        chunkRefs = this.chunkRefs.get(entry.id);
+      } else {
+        chunkRefs = new Set();
+        this.chunkRefs.set(entry.id, chunkRefs);
+      }
+
+      // Add chunk reference to entry.
+      chunkRefs.add(index);
+
+      // If the doodad is pending unload, remove the pending unload.
+      if (this.entriesPendingUnload.has(entry.id)) {
+        this.entriesPendingUnload.delete(entry.id);
+      }
+
+      // Add to pending loads. Actual loading is done by interval.
+      this.entriesPendingLoad.set(entry.id, entry);
+    }
+  }
+
+  unloadChunk(index, entries) {
+    for (let i = 0, len = entries.length; i < len; ++i) {
+      const entry = entries[i];
+
+      const chunkRefs = this.chunkRefs.get(entry.id);
+
+      // Remove chunk reference for entry.
+      chunkRefs.delete(index);
+
+      // If at least one chunk reference remains for entry, leave loaded. Typically happens in
+      // cases where a doodad is shared across multiple chunks.
+      if (chunkRefs.size > 0) {
+        continue;
+      }
+
+      // No chunk references remain, so we should remove from pending loads if necessary.
+      if (this.entriesPendingLoad.has(entry.id)) {
+        this.entriesPendingLoad.delete(entry.id);
+      }
+
+      // Add to pending unloads. Actual unloading is done by interval.
+      this.entriesPendingUnload.set(entry.id, entry);
+    }
+  }
+
+  // Every tick of the load interval, load a portion of any doodads pending load.
+  loadDoodads() {
+    let count = 0;
+
+    for (const entry of this.entriesPendingLoad.values()) {
+      if (this.doodads.has(entry.id)) {
+        this.entriesPendingLoad.delete(entry.id);
+        continue;
+      }
+
+      this.loadDoodad(entry);
+
+      this.entriesPendingLoad.delete(entry.id);
+
+      ++count;
+
+      if (count > this.entriesPendingLoad.size * this.constructor.LOAD_FACTOR) {
+        return;
+      }
+    }
+  }
+
+  loadDoodad(entry) {
+    M2.load(entry.filename).then((doodad) => {
+      if (this.entriesPendingUnload.has(entry.id)) {
+        return;
+      }
+
+      doodad.entryID = entry.id;
+
+      this.doodads.set(entry.id, doodad);
+
+      this.placeDoodad(doodad, entry.position, entry.rotation, entry.scale);
+
+      if (doodad.animated) {
+        this.animateDoodad(entry, doodad);
+      }
+    });
+  }
+
+  animateDoodad(entry, doodad) {
+    // Maintain separate entries for animated doodads to avoid excessive iterations on each
+    // call to animate() during the render loop.
+    this.animatedDoodads.set(entry.id, doodad);
+
+    // Auto-play animation index 0 in doodad, if animations are present.
+    // TODO: Properly manage doodad animations.
+    if (doodad.animations.length > 0) {
+      doodad.animations.play(0);
+    }
+  }
+
+  // Every tick of the load interval, unload a portion of any doodads pending unload.
+  unloadDoodads() {
+    let count = 0;
+
+    for (const entry of this.entriesPendingUnload.values()) {
+      // If the doodad was already unloaded, remove it from the pending unloads.
+      if (!this.doodads.has(entry.id)) {
+        this.entriesPendingUnload.delete(entry.id);
+        continue;
+      }
+
+      this.unloadDoodad(entry);
+
+      this.entriesPendingUnload.delete(entry.id);
+
+      ++count;
+
+      if (count > this.entriesPendingUnload.size * this.constructor.LOAD_FACTOR) {
+        return;
+      }
+    }
+  }
+
+  unloadDoodad(entry) {
+    const doodad = this.doodads.get(entry.id);
+    this.doodads.delete(entry.id);
+    this.animatedDoodads.delete(entry.id);
+    this.map.remove(doodad);
+  }
+
+  // Place a doodad on the world map, adhereing to a provided position, rotation, and scale.
+  placeDoodad(doodad, position, rotation, scale) {
+    doodad.position.set(
+      -(position.z - this.map.constructor.ZEROPOINT),
+      -(position.x - this.map.constructor.ZEROPOINT),
+      position.y
+    );
+
+    // Provided as (Z, X, -Y)
+    doodad.rotation.set(
+      rotation.z * Math.PI / 180,
+      rotation.x * Math.PI / 180,
+      -rotation.y * Math.PI / 180
+    );
+
+    // Adjust doodad rotation to match Wowser's axes.
+    const quat = doodad.quaternion;
+    quat.set(quat.x, quat.y, quat.z, -quat.w);
+
+    if (scale !== 1024) {
+      const scaleFloat = scale / 1024;
+      doodad.scale.set(scaleFloat, scaleFloat, scaleFloat);
+    }
+
+    // Add doodad to world map.
+    this.map.add(doodad);
+    doodad.updateMatrix();
+  }
+
+  animate(delta, camera, cameraRotated) {
+    this.animatedDoodads.forEach((doodad) => {
+      if (!doodad.visible) {
+        return;
+      }
+
+      if (doodad.animations.length > 0) {
+        doodad.animations.update(delta);
+      }
+
+      if (cameraRotated && doodad.billboards.length > 0) {
+        doodad.applyBillboards(camera);
+      }
+
+      if (doodad.skeletonHelper) {
+        doodad.skeletonHelper.update();
+      }
+    });
+  }
+
+}
+
+export default DoodadManager;

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -11,6 +11,8 @@ class WorldHandler extends EventEmitter {
     this.player = this.session.player;
 
     this.scene = new THREE.Scene();
+    this.scene.matrixAutoUpdate = false;
+
     this.map = null;
 
     this.changeMap = ::this.changeMap;

--- a/src/lib/game/world/handler.js
+++ b/src/lib/game/world/handler.js
@@ -114,16 +114,7 @@ class WorldHandler extends EventEmitter {
     });
   }
 
-  changeModel(_unit, oldModel, newModel) {
-    // Only need to handle skeleton helper changes here
-    if (oldModel && oldModel.skeletonHelper) {
-      this.scene.remove(oldModel.skeletonHelper);
-    }
-
-    if (newModel) {
-      newModel.skeletonHelper = new THREE.SkeletonHelper(newModel);
-      this.scene.add(newModel.skeletonHelper);
-    }
+  changeModel(_unit, _oldModel, _newModel) {
   }
 
   changePosition(player) {

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -26,8 +26,6 @@ class WorldMap extends THREE.Group {
     this.doodadManager = new DoodadManager(this);
     this.wmoManager = new WMOManager(this);
 
-    window.wmoManager = this.wmoManager;
-
     this.data = data;
     this.wdt = wdt;
 

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -12,10 +12,19 @@ class WorldMap extends THREE.Group {
   static ZEROPOINT = ADT.SIZE * 32;
 
   static CHUNKS_PER_ROW = 64 * 16;
-  static CHUNK_RENDER_RADIUS = 10;
+
+  // Controls when ADT chunks are loaded and unloaded from the map.
+  static CHUNK_RENDER_RADIUS = 16;
+
+  // Controls when terrain, map doodads, and map objects are flagged as visible.
+  static TERRAIN_VISIBILITY_RADIUS = 16;
+  static MAP_DOODAD_VISIBILITY_RADIUS = 12;
+  static WMO_VISIBILITY_RADIUS = 8;
 
   constructor(data, wdt) {
     super();
+
+    this.matrixAutoUpdate = false;
 
     this.data = data;
     this.wdt = wdt;
@@ -49,6 +58,9 @@ class WorldMap extends THREE.Group {
     this.chunkX = chunkX;
     this.chunkY = chunkY;
 
+    this.updateVisibilityRadii();
+    this.updateVisibilities();
+
     const radius = this.constructor.CHUNK_RENDER_RADIUS;
     const indices = this.chunkIndicesAround(chunkX, chunkY, radius);
 
@@ -78,6 +90,46 @@ class WorldMap extends THREE.Group {
     return indices;
   }
 
+  updateVisibilityRadii() {
+    this.visibleTerrainIndices = this.chunkIndicesAround(
+      this.chunkX,
+      this.chunkY,
+      this.constructor.TERRAIN_VISIBILITY_RADIUS
+    );
+
+    this.visibleDoodadIndices = this.chunkIndicesAround(
+      this.chunkX,
+      this.chunkY,
+      this.constructor.MAP_DOODAD_VISIBILITY_RADIUS
+    );
+
+    this.visibleWMOIndices = this.chunkIndicesAround(
+      this.chunkX,
+      this.chunkY,
+      this.constructor.WMO_VISIBILITY_RADIUS
+    );
+  }
+
+  updateVisibilities() {
+    this.chunks.forEach((chunk, index) => {
+      // Terrain visibility
+      const terrainVisible = this.visibleTerrainIndices.indexOf(index) !== -1;
+      chunk.visible = terrainVisible;
+
+      // Doodad visibility
+      const doodadsVisible = this.visibleDoodadIndices.indexOf(index) !== -1;
+      for (let i = 0, len = chunk.loadedDoodads.length; i < len; ++i) {
+        chunk.loadedDoodads[i].visible = doodadsVisible;
+      }
+
+      // WMO visibility
+      const wmosVisible = this.visibleWMOIndices.indexOf(index) !== -1;
+      for (let i = 0, len = chunk.loadedWMOs.length; i < len; ++i) {
+        chunk.loadedWMOs[i].visible = wmosVisible;
+      }
+    });
+  }
+
   loadChunkByIndex(index) {
     if (this.queuedChunks.has(index)) {
       return;
@@ -88,17 +140,26 @@ class WorldMap extends THREE.Group {
     const chunkY = index % perRow;
 
     this.queuedChunks.set(index, Chunk.load(this, chunkX, chunkY).then((chunk) => {
+      chunk.index = index;
+
       this.chunks.set(index, chunk);
 
+      chunk.loadedWMOs = [];
+      chunk.loadedDoodads = [];
+
       chunk.doodadEntries.forEach((entry) => {
-        this.loadDoodad(entry);
+        this.loadDoodad(chunk, entry);
       });
 
       chunk.wmoEntries.forEach((entry) => {
-        this.loadWMO(entry);
+        this.loadWMO(chunk, entry);
       });
 
+      // Control initial terrain visibility.
+      chunk.visible = this.visibleTerrainIndices.indexOf(index) !== -1;
+
       this.add(chunk);
+      chunk.updateMatrix();
     }));
   }
 
@@ -112,18 +173,34 @@ class WorldMap extends THREE.Group {
     this.queuedChunks.delete(index);
     this.chunks.delete(index);
     this.remove(chunk);
+
+    chunk.loadedDoodads.forEach((doodad) => {
+      this.queuedDoodads.delete(doodad.entryID);
+      this.doodads.delete(doodad.entryID);
+      this.remove(doodad);
+    });
+    chunk.loadedDoodads = [];
+
+    chunk.loadedWMOs.forEach((wmo) => {
+      this.queuedWMOs.delete(wmo.entryID);
+      this.wmos.delete(wmo.entryID);
+      this.remove(wmo);
+    });
+    chunk.loadedWMOs = [];
   }
 
   indexFor(chunkX, chunkY) {
     return chunkX * 64 * 16 + chunkY;
   }
 
-  loadDoodad(entry) {
+  loadDoodad(chunk, entry) {
     if (this.queuedDoodads.has(entry.id)) {
       return;
     }
 
     this.queuedDoodads.set(entry.id, M2.load(entry.filename).then((m2) => {
+      m2.entryID = entry.id;
+
       m2.position.set(
         -(entry.position.z - this.constructor.ZEROPOINT),
         -(entry.position.x - this.constructor.ZEROPOINT),
@@ -146,10 +223,16 @@ class WorldMap extends THREE.Group {
         m2.scale.set(scale, scale, scale);
       }
 
+      // Control initial map doodad visibility.
+      m2.visible = this.visibleDoodadIndices.indexOf(chunk.index) !== -1;
+
       this.add(m2);
+      m2.updateMatrix();
 
       // TODO: Remove doodad from map on unload
       this.doodads.set(entry.id, m2);
+      chunk.loadedDoodads.push(m2);
+      // this.queuedDoodads.delete(entry.id);
 
       // Auto-play animation index 0 in doodad, if animations are present
       // TODO: Properly manage doodad animations
@@ -159,19 +242,19 @@ class WorldMap extends THREE.Group {
     }));
   }
 
-  loadWMO(entry) {
+  loadWMO(chunk, entry) {
     if (this.queuedWMOs.has(entry.id)) {
       return;
     }
 
     this.queuedWMOs.set(entry.id, WMO.load(entry.filename).then((wmo) => {
+      wmo.entryID = entry.id;
+
       wmo.position.set(
         -(entry.position.z - this.constructor.ZEROPOINT),
         -(entry.position.x - this.constructor.ZEROPOINT),
         entry.position.y
       );
-
-      wmo.doodadSet = entry.doodadSet;
 
       // Provided as (Z, X, -Y)
       wmo.rotation.set(
@@ -184,10 +267,18 @@ class WorldMap extends THREE.Group {
       const quat = wmo.quaternion;
       quat.set(quat.x, quat.y, quat.z, -quat.w);
 
+      // Control initial WMO visibility.
+      wmo.visible = this.visibleWMOIndices.indexOf(chunk.index) !== -1;
+
+      wmo.doodadSet = entry.doodadSet;
+
       this.add(wmo);
+      wmo.updateMatrix();
 
       // TODO: Remove WMO from map on unload
       this.wmos.set(entry.id, wmo);
+      chunk.loadedWMOs.push(wmo);
+      // this.queuedWMOs.delete(entry.id);
     }));
   }
 
@@ -197,7 +288,7 @@ class WorldMap extends THREE.Group {
 
   animateDoodads(delta, camera, cameraRotated) {
     this.doodads.forEach((doodad) => {
-      if (!doodad.animated) {
+      if (!doodad.animated || !doodad.visible) {
         return;
       }
 

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -3,9 +3,10 @@ import THREE from 'three';
 import ADT from '../../pipeline/adt';
 import Chunk from '../../pipeline/adt/chunk';
 import DBC from '../../pipeline/dbc';
-import M2 from '../../pipeline/m2';
 import WDT from '../../pipeline/wdt';
-import WMO from '../../pipeline/wmo';
+import DoodadManager from './doodad-manager';
+import WMOManager from './wmo-manager';
+import TerrainManager from './terrain-manager';
 
 class WorldMap extends THREE.Group {
 
@@ -14,17 +15,18 @@ class WorldMap extends THREE.Group {
   static CHUNKS_PER_ROW = 64 * 16;
 
   // Controls when ADT chunks are loaded and unloaded from the map.
-  static CHUNK_RENDER_RADIUS = 16;
-
-  // Controls when terrain, map doodads, and map objects are flagged as visible.
-  static TERRAIN_VISIBILITY_RADIUS = 16;
-  static MAP_DOODAD_VISIBILITY_RADIUS = 12;
-  static WMO_VISIBILITY_RADIUS = 8;
+  static CHUNK_RENDER_RADIUS = 12;
 
   constructor(data, wdt) {
     super();
 
     this.matrixAutoUpdate = false;
+
+    this.terrainManager = new TerrainManager(this);
+    this.doodadManager = new DoodadManager(this);
+    this.wmoManager = new WMOManager(this);
+
+    window.wmoManager = this.wmoManager;
 
     this.data = data;
     this.wdt = wdt;
@@ -35,12 +37,6 @@ class WorldMap extends THREE.Group {
 
     this.queuedChunks = new Map();
     this.chunks = new Map();
-
-    this.queuedDoodads = new Map();
-    this.doodads = new Map();
-
-    this.queuedWMOs = new Map();
-    this.wmos = new Map();
   }
 
   get internalName() {
@@ -58,9 +54,6 @@ class WorldMap extends THREE.Group {
     this.chunkX = chunkX;
     this.chunkY = chunkY;
 
-    this.updateVisibilityRadii();
-    this.updateVisibilities();
-
     const radius = this.constructor.CHUNK_RENDER_RADIUS;
     const indices = this.chunkIndicesAround(chunkX, chunkY, radius);
 
@@ -73,6 +66,10 @@ class WorldMap extends THREE.Group {
         this.unloadChunkByIndex(index);
       }
     });
+
+    this.terrainManager.updateCurrentChunk(chunkX, chunkY);
+    this.doodadManager.updateCurrentChunk(chunkX, chunkY);
+    this.wmoManager.updateCurrentChunk(chunkX, chunkY);
   }
 
   chunkIndicesAround(chunkX, chunkY, radius) {
@@ -90,46 +87,6 @@ class WorldMap extends THREE.Group {
     return indices;
   }
 
-  updateVisibilityRadii() {
-    this.visibleTerrainIndices = this.chunkIndicesAround(
-      this.chunkX,
-      this.chunkY,
-      this.constructor.TERRAIN_VISIBILITY_RADIUS
-    );
-
-    this.visibleDoodadIndices = this.chunkIndicesAround(
-      this.chunkX,
-      this.chunkY,
-      this.constructor.MAP_DOODAD_VISIBILITY_RADIUS
-    );
-
-    this.visibleWMOIndices = this.chunkIndicesAround(
-      this.chunkX,
-      this.chunkY,
-      this.constructor.WMO_VISIBILITY_RADIUS
-    );
-  }
-
-  updateVisibilities() {
-    this.chunks.forEach((chunk, index) => {
-      // Terrain visibility
-      const terrainVisible = this.visibleTerrainIndices.indexOf(index) !== -1;
-      chunk.visible = terrainVisible;
-
-      // Doodad visibility
-      const doodadsVisible = this.visibleDoodadIndices.indexOf(index) !== -1;
-      for (let i = 0, len = chunk.loadedDoodads.length; i < len; ++i) {
-        chunk.loadedDoodads[i].visible = doodadsVisible;
-      }
-
-      // WMO visibility
-      const wmosVisible = this.visibleWMOIndices.indexOf(index) !== -1;
-      for (let i = 0, len = chunk.loadedWMOs.length; i < len; ++i) {
-        chunk.loadedWMOs[i].visible = wmosVisible;
-      }
-    });
-  }
-
   loadChunkByIndex(index) {
     if (this.queuedChunks.has(index)) {
       return;
@@ -140,26 +97,11 @@ class WorldMap extends THREE.Group {
     const chunkY = index % perRow;
 
     this.queuedChunks.set(index, Chunk.load(this, chunkX, chunkY).then((chunk) => {
-      chunk.index = index;
-
       this.chunks.set(index, chunk);
 
-      chunk.loadedWMOs = [];
-      chunk.loadedDoodads = [];
-
-      chunk.doodadEntries.forEach((entry) => {
-        this.loadDoodad(chunk, entry);
-      });
-
-      chunk.wmoEntries.forEach((entry) => {
-        this.loadWMO(chunk, entry);
-      });
-
-      // Control initial terrain visibility.
-      chunk.visible = this.visibleTerrainIndices.indexOf(index) !== -1;
-
-      this.add(chunk);
-      chunk.updateMatrix();
+      this.terrainManager.loadChunk(index, chunk);
+      this.doodadManager.loadChunk(index, chunk.doodadEntries);
+      this.wmoManager.loadChunk(index, chunk.wmoEntries);
     }));
   }
 
@@ -169,141 +111,21 @@ class WorldMap extends THREE.Group {
       return;
     }
 
-    // TODO: Unload doodads and WMOs
+    this.terrainManager.unloadChunk(index, chunk);
+    this.doodadManager.unloadChunk(index, chunk.doodadEntries);
+    this.wmoManager.unloadChunk(index, chunk.wmoEntries);
+
     this.queuedChunks.delete(index);
     this.chunks.delete(index);
-    this.remove(chunk);
-
-    chunk.loadedDoodads.forEach((doodad) => {
-      this.queuedDoodads.delete(doodad.entryID);
-      this.doodads.delete(doodad.entryID);
-      this.remove(doodad);
-    });
-    chunk.loadedDoodads = [];
-
-    chunk.loadedWMOs.forEach((wmo) => {
-      this.queuedWMOs.delete(wmo.entryID);
-      this.wmos.delete(wmo.entryID);
-      this.remove(wmo);
-    });
-    chunk.loadedWMOs = [];
   }
 
   indexFor(chunkX, chunkY) {
     return chunkX * 64 * 16 + chunkY;
   }
 
-  loadDoodad(chunk, entry) {
-    if (this.queuedDoodads.has(entry.id)) {
-      return;
-    }
-
-    this.queuedDoodads.set(entry.id, M2.load(entry.filename).then((m2) => {
-      m2.entryID = entry.id;
-
-      m2.position.set(
-        -(entry.position.z - this.constructor.ZEROPOINT),
-        -(entry.position.x - this.constructor.ZEROPOINT),
-        entry.position.y
-      );
-
-      // Provided as (Z, X, -Y)
-      m2.rotation.set(
-        entry.rotation.z * Math.PI / 180,
-        entry.rotation.x * Math.PI / 180,
-        -entry.rotation.y * Math.PI / 180
-      );
-
-      // Adjust M2 rotation to match Wowser's axes.
-      const quat = m2.quaternion;
-      quat.set(quat.x, quat.y, quat.z, -quat.w);
-
-      if (entry.scale !== 1024) {
-        const scale = entry.scale / 1024;
-        m2.scale.set(scale, scale, scale);
-      }
-
-      // Control initial map doodad visibility.
-      m2.visible = this.visibleDoodadIndices.indexOf(chunk.index) !== -1;
-
-      this.add(m2);
-      m2.updateMatrix();
-
-      // TODO: Remove doodad from map on unload
-      this.doodads.set(entry.id, m2);
-      chunk.loadedDoodads.push(m2);
-      // this.queuedDoodads.delete(entry.id);
-
-      // Auto-play animation index 0 in doodad, if animations are present
-      // TODO: Properly manage doodad animations
-      if (m2.animated && m2.animations.length > 0) {
-        m2.animations.play(0);
-      }
-    }));
-  }
-
-  loadWMO(chunk, entry) {
-    if (this.queuedWMOs.has(entry.id)) {
-      return;
-    }
-
-    this.queuedWMOs.set(entry.id, WMO.load(entry.filename).then((wmo) => {
-      wmo.entryID = entry.id;
-
-      wmo.position.set(
-        -(entry.position.z - this.constructor.ZEROPOINT),
-        -(entry.position.x - this.constructor.ZEROPOINT),
-        entry.position.y
-      );
-
-      // Provided as (Z, X, -Y)
-      wmo.rotation.set(
-        entry.rotation.z * Math.PI / 180,
-        entry.rotation.x * Math.PI / 180,
-        -entry.rotation.y * Math.PI / 180
-      );
-
-      // Adjust WMO rotation to match Wowser's axes.
-      const quat = wmo.quaternion;
-      quat.set(quat.x, quat.y, quat.z, -quat.w);
-
-      // Control initial WMO visibility.
-      wmo.visible = this.visibleWMOIndices.indexOf(chunk.index) !== -1;
-
-      wmo.doodadSet = entry.doodadSet;
-
-      this.add(wmo);
-      wmo.updateMatrix();
-
-      // TODO: Remove WMO from map on unload
-      this.wmos.set(entry.id, wmo);
-      chunk.loadedWMOs.push(wmo);
-      // this.queuedWMOs.delete(entry.id);
-    }));
-  }
-
   animate(delta, camera, cameraRotated) {
-    this.animateDoodads(delta, camera, cameraRotated);
-  }
-
-  animateDoodads(delta, camera, cameraRotated) {
-    this.doodads.forEach((doodad) => {
-      if (!doodad.animated || !doodad.visible) {
-        return;
-      }
-
-      if (doodad.animations.length > 0) {
-        doodad.animations.update(delta);
-      }
-
-      if (cameraRotated && doodad.billboards.length > 0) {
-        doodad.applyBillboards(camera);
-      }
-
-      if (doodad.skeletonHelper) {
-        doodad.skeletonHelper.update();
-      }
-    });
+    this.doodadManager.animate(delta, camera, cameraRotated);
+    this.wmoManager.animate(delta, camera, cameraRotated);
   }
 
   static load(id) {

--- a/src/lib/game/world/map.js
+++ b/src/lib/game/world/map.js
@@ -66,10 +66,6 @@ class WorldMap extends THREE.Group {
         this.unloadChunkByIndex(index);
       }
     });
-
-    this.terrainManager.updateCurrentChunk(chunkX, chunkY);
-    this.doodadManager.updateCurrentChunk(chunkX, chunkY);
-    this.wmoManager.updateCurrentChunk(chunkX, chunkY);
   }
 
   chunkIndicesAround(chunkX, chunkY, radius) {

--- a/src/lib/game/world/terrain-manager.js
+++ b/src/lib/game/world/terrain-manager.js
@@ -11,6 +11,7 @@ class TerrainManager {
 
   unloadChunk(_index, terrain) {
     this.map.remove(terrain);
+    terrain.dispose();
   }
 
 }

--- a/src/lib/game/world/terrain-manager.js
+++ b/src/lib/game/world/terrain-manager.js
@@ -1,0 +1,43 @@
+class TerrainManager {
+
+  // Radius in chunks for which terrain should appear.
+  // TODO: Even worth the bother to implement this?
+  static VISIBILITY_RADIUS = 12;
+
+  constructor(map) {
+    this.map = map;
+
+    this.chunkX = null;
+    this.chunkY = null;
+
+    this.visibleChunks = [];
+    this.visibleTerrainCount = 0;
+  }
+
+  updateCurrentChunk(chunkX, chunkY) {
+    this.chunkX = chunkX;
+    this.chunkY = chunkY;
+
+    this.calculateVisibleChunks();
+  }
+
+  calculateVisibleChunks() {
+    this.visibleChunks = this.map.chunkIndicesAround(
+      this.chunkX,
+      this.chunkY,
+      this.constructor.VISIBILITY_RADIUS
+    );
+  }
+
+  loadChunk(index, terrain) {
+    this.map.add(terrain);
+    terrain.updateMatrix();
+  }
+
+  unloadChunk(index, terrain) {
+    this.map.remove(terrain);
+  }
+
+}
+
+export default TerrainManager;

--- a/src/lib/game/world/terrain-manager.js
+++ b/src/lib/game/world/terrain-manager.js
@@ -1,32 +1,7 @@
 class TerrainManager {
 
-  // Radius in chunks for which terrain should appear.
-  // TODO: Even worth the bother to implement this?
-  static VISIBILITY_RADIUS = 12;
-
   constructor(map) {
     this.map = map;
-
-    this.chunkX = null;
-    this.chunkY = null;
-
-    this.visibleChunks = [];
-    this.visibleTerrainCount = 0;
-  }
-
-  updateCurrentChunk(chunkX, chunkY) {
-    this.chunkX = chunkX;
-    this.chunkY = chunkY;
-
-    this.calculateVisibleChunks();
-  }
-
-  calculateVisibleChunks() {
-    this.visibleChunks = this.map.chunkIndicesAround(
-      this.chunkX,
-      this.chunkY,
-      this.constructor.VISIBILITY_RADIUS
-    );
   }
 
   loadChunk(index, terrain) {

--- a/src/lib/game/world/terrain-manager.js
+++ b/src/lib/game/world/terrain-manager.js
@@ -4,12 +4,12 @@ class TerrainManager {
     this.map = map;
   }
 
-  loadChunk(index, terrain) {
+  loadChunk(_index, terrain) {
     this.map.add(terrain);
     terrain.updateMatrix();
   }
 
-  unloadChunk(index, terrain) {
+  unloadChunk(_index, terrain) {
     this.map.remove(terrain);
   }
 

--- a/src/lib/game/world/wmo-manager.js
+++ b/src/lib/game/world/wmo-manager.js
@@ -1,4 +1,6 @@
 import WMO from '../../pipeline/wmo';
+import WMOBlueprint from '../../pipeline/wmo/blueprint';
+import WMOGroupBlueprint from '../../pipeline/wmo/group/blueprint';
 
 class WMOManager {
 
@@ -170,7 +172,7 @@ class WMOManager {
   }
 
   loadWMO(entry) {
-    WMO.load(entry.filename).then((wmo) => {
+    WMOBlueprint.load(entry.filename).then((wmo) => {
       if (this.wmos.has(entry.id)) {
         return;
       }
@@ -329,7 +331,7 @@ class WMOManager {
         }
       }
 
-      // We've loaded all doodads for this root WMO entry.
+      // We've loaded all doodads for this WMO group.
       if (doodadEntries.size === 0) {
         this.doodadsPendingLoad.delete(group);
       }
@@ -390,24 +392,26 @@ class WMOManager {
       this.largeGroupsPendingLoad.delete(entry.id);
     }
 
+    this.map.remove(wmo);
+
     wmo.groups.forEach((group) => {
       this.unloadWMOGroup(group);
     });
 
-    this.map.remove(wmo);
-
-    wmo.dispose();
+    WMOBlueprint.unload(wmo);
   }
 
   unloadWMOGroup(group) {
     if (this.doodadsPendingLoad.has(group)) {
-      this.doodadsPendingLoadCount -= this.doodadsPendingLoad.get(group).size;
       this.doodadsPendingLoad.delete(group);
+      this.doodadsPendingLoadCount -= this.doodadsPendingLoad.get(group).size;
     }
+
+    group.parent.remove(group);
 
     group.unloadDoodads();
 
-    group.parent.remove(group);
+    WMOGroupBlueprint.unload(group);
   }
 
   animate(_delta, _camera, _cameraRotated) {

--- a/src/lib/game/world/wmo-manager.js
+++ b/src/lib/game/world/wmo-manager.js
@@ -395,6 +395,8 @@ class WMOManager {
     });
 
     this.map.remove(wmo);
+
+    wmo.dispose();
   }
 
   unloadWMOGroup(group) {
@@ -402,6 +404,8 @@ class WMOManager {
       this.doodadsPendingLoadCount -= this.doodadsPendingLoad.get(group).size;
       this.doodadsPendingLoad.delete(group);
     }
+
+    group.unloadDoodads();
 
     group.parent.remove(group);
   }

--- a/src/lib/game/world/wmo-manager.js
+++ b/src/lib/game/world/wmo-manager.js
@@ -36,9 +36,6 @@ class WMOManager {
     this.map = map;
     this.chunkRefs = new Map();
 
-    this.chunkX = null;
-    this.chunkY = null;
-
     this.groupsPendingLoadCount = 0;
     this.groupCount = 0;
     this.doodadsPendingLoadCount = 0;

--- a/src/lib/game/world/wmo-manager.js
+++ b/src/lib/game/world/wmo-manager.js
@@ -1,0 +1,372 @@
+import WMO from '../../pipeline/wmo';
+
+class WMOManager {
+
+  // Radius in chunks for which WMOs should appear.
+  // TODO: Even worth the bother to implement this?
+  static VISIBILITY_RADIUS = 12;
+
+  // Determines if regular or slow loading will be used to ingress WMO groups to the map. Used
+  // to prevent very large WMOs from killing performance when the player navigates nearby.
+  static LARGE_THRESHOLD = 60;
+
+  // Proportion of pending WMO groups to load or unload in a given tick.
+  // Ex: 1 / 120 aims to have all currently pending WMO groups loaded within 2 seconds.
+  static LOAD_FACTOR = 1 / 120;
+
+  // Same as above, but used for WMOs with more than LARGE_THRESHOLD groups.
+  // Ex: 1 / 900 aims to have all currently pending large WMO groups loaded within 15 seconds.
+  static LARGE_LOAD_FACTOR = 1 / 900;
+
+  // Number of milliseconds to wait before loading another portion of WMO groups.
+  static LOAD_INTERVAL = (1 / 60) * 1000;
+
+  // Number of milliseconds to wait before unloading a root WMO (and its groups).
+  static ROOT_UNLOAD_DELAY = 30 * 1000;
+
+  static DOODAD_LOAD_FACTOR = 1 / 300;
+
+  // Number of milliseconds to wait before loading another portion of WMO doodads.
+  static DOODAD_LOAD_INTERVAL = (1 / 60) * 1000;
+
+  constructor(map) {
+    this.map = map;
+    this.chunkRefs = new Map();
+
+    this.chunkX = null;
+    this.chunkY = null;
+
+    this.visibleWMOCount = 0;
+    this.groupsPendingLoadCount = 0;
+    this.groupCount = 0;
+    this.doodadsPendingLoadCount = 0;
+    this.doodadCount = 0;
+
+    this.wmos = new Map();
+
+    this.entriesPendingLoad = new Map();
+    this.entriesPendingUnload = new Map();
+    this.entriesDelayingUnload = new Map();
+
+    this.groupsPendingLoad = new Map();
+    this.groupsPendingUnload = new Map();
+    this.largeGroupsPendingLoad = new Map();
+    this.largeGroupsPendingUnload = new Map();
+
+    this.doodadsPendingLoad = new Map();
+
+    this.loadChunk = ::this.loadChunk;
+    this.unloadChunk = ::this.unloadChunk;
+    this.loadWMOs = ::this.loadWMOs;
+    this.loadWMOGroups = ::this.loadWMOGroups;
+    this.loadLargeWMOGroups = ::this.loadLargeWMOGroups;
+    this.loadWMOGroup = ::this.loadWMOGroup;
+    this.loadWMODoodads = ::this.loadWMODoodads;
+    this.addPendingUnload = ::this.addPendingUnload;
+    this.unloadWMOs = ::this.unloadWMOs;
+
+    setInterval(this.loadWMOs, 1);
+    setInterval(this.unloadWMOs, this.constructor.LOAD_INTERVAL);
+    setInterval(this.loadWMOGroups, this.constructor.LOAD_INTERVAL);
+    setInterval(this.loadLargeWMOGroups, this.constructor.LOAD_INTERVAL);
+    setInterval(this.loadWMODoodads, this.constructor.DOODAD_LOAD_INTERVAL);
+  }
+
+  updateCurrentChunk(chunkX, chunkY) {
+    this.chunkX = chunkX;
+    this.chunkY = chunkY;
+
+    this.calculateVisibleChunks();
+  }
+
+  calculateVisibleChunks() {
+    this.visibleChunks = this.map.chunkIndicesAround(
+      this.chunkX,
+      this.chunkY,
+      this.constructor.VISIBILITY_RADIUS
+    );
+  }
+
+  // Process a set of WMO entries for a given chunk index of the world map.
+  loadChunk(index, entries) {
+    for (let i = 0, len = entries.length; i < len; ++i) {
+      const entry = entries[i];
+
+      let chunkRefs;
+
+      // Fetch or create chunk references for entry.
+      if (this.chunkRefs.has(entry.id)) {
+        chunkRefs = this.chunkRefs.get(entry.id);
+      } else {
+        chunkRefs = new Set();
+        this.chunkRefs.set(entry.id, chunkRefs);
+      }
+
+      // Add chunk reference to entry.
+      chunkRefs.add(index);
+
+      // If the WMO is pending unload, remove the pending unload.
+      if (this.entriesPendingUnload.has(entry.id)) {
+        this.entriesPendingUnload.delete(entry.id);
+      }
+
+      // If the WMO is delaying unload, remove the delaying unload.
+      if (this.entriesDelayingUnload.has(entry.id)) {
+        clearTimeout(this.entriesDelayingUnload.get(entry.id));
+        this.entriesDelayingUnload.delete(entry.id);
+      }
+
+      // Add to pending loads. Actual loading is done by interval.
+      this.entriesPendingLoad.set(entry.id, entry);
+    }
+  }
+
+  unloadChunk(index, entries) {
+    for (let i = 0, len = entries.length; i < len; ++i) {
+      const entry = entries[i];
+
+      const chunkRefs = this.chunkRefs.get(entry.id);
+
+      // Remove chunk reference for entry.
+      chunkRefs.delete(index);
+
+      // If at least one chunk reference remains for entry, leave loaded. Typically happens in
+      // cases where a doodad is shared across multiple chunks.
+      if (chunkRefs.size > 0) {
+        continue;
+      }
+
+      // No chunk references remain, so we should remove from pending loads if necessary.
+      if (this.entriesPendingLoad.has(entry.id)) {
+        this.entriesPendingLoad.delete(entry.id);
+      }
+
+      // Add to delaying unloads. Actual unloading is done by interval.
+      this.entriesDelayingUnload.set(
+        entry.id,
+        setTimeout(this.addPendingUnload, this.constructor.ROOT_UNLOAD_DELAY, entry)
+      );
+    }
+  }
+
+  addPendingUnload(entry) {
+    this.entriesPendingUnload.set(entry.id, entry);
+    this.entriesDelayingUnload.delete(entry.id);
+  }
+
+  // Every tick of the load interval, load a portion of any WMOs pending load.
+  loadWMOs() {
+    let count = 0;
+
+    for (const entry of this.entriesPendingLoad.values()) {
+      if (this.wmos.has(entry.id)) {
+        this.entriesPendingLoad.delete(entry.id);
+        continue;
+      }
+
+      this.loadWMO(entry);
+
+      this.entriesPendingLoad.delete(entry.id);
+
+      ++count;
+
+      if (count > this.entriesPendingLoad.size * this.constructor.LOAD_FACTOR) {
+        return;
+      }
+    }
+  }
+
+  loadWMO(entry) {
+    WMO.load(entry.filename).then((wmo) => {
+      if (this.wmos.has(entry.id)) {
+        return;
+      }
+
+      wmo.requestedDoodadSet = entry.doodadSet;
+
+      this.placeWMO(wmo, entry.position, entry.rotation);
+
+      this.wmos.set(entry.id, wmo);
+
+      this.groupsPendingLoadCount += wmo.groupCount;
+
+      let groupsPendingLoad;
+
+      if (wmo.groupCount > this.constructor.LARGE_THRESHOLD) {
+        if (!this.largeGroupsPendingLoad.has(entry.id)) {
+          this.largeGroupsPendingLoad.set(entry.id, new Set());
+        }
+
+        groupsPendingLoad = this.largeGroupsPendingLoad.get(entry.id);
+      } else {
+        if (!this.groupsPendingLoad.has(entry.id)) {
+          this.groupsPendingLoad.set(entry.id, new Set());
+        }
+
+        groupsPendingLoad = this.groupsPendingLoad.get(entry.id);
+      }
+
+      // Add outdoor groups to pending loads.
+      for (let ogi = 0, oglen = wmo.outdoorGroupIndices.length; ogi < oglen; ++ogi) {
+        groupsPendingLoad.add(wmo.outdoorGroupIndices[ogi]);
+      }
+
+      // Add indoor groups to pending loads.
+      for (let igi = 0, iglen = wmo.indoorGroupIndices.length; igi < iglen; ++igi) {
+        groupsPendingLoad.add(wmo.indoorGroupIndices[igi]);
+      }
+    });
+  }
+
+  // Place a WMO on the world map, adhereing to a provided position and rotation.
+  placeWMO(wmo, position, rotation) {
+    wmo.position.set(
+      -(position.z - this.map.constructor.ZEROPOINT),
+      -(position.x - this.map.constructor.ZEROPOINT),
+      position.y
+    );
+
+    // Provided as (Z, X, -Y)
+    wmo.rotation.set(
+      rotation.z * Math.PI / 180,
+      rotation.x * Math.PI / 180,
+      -rotation.y * Math.PI / 180
+    );
+
+    // Adjust WMO rotation to match Wowser's axes.
+    const quat = wmo.quaternion;
+    quat.set(quat.x, quat.y, quat.z, -quat.w);
+
+    this.map.add(wmo);
+    wmo.updateMatrix();
+  }
+
+  // Every tick of the load interval, load a portion of any WMO groups pending load.
+  loadWMOGroups() {
+    this.loadWMOGroupsInternal(this.groupsPendingLoad, this.constructor.LOAD_FACTOR);
+  }
+
+  loadLargeWMOGroups() {
+    this.loadWMOGroupsInternal(this.largeGroupsPendingLoad, this.constructor.LARGE_LOAD_FACTOR);
+  }
+
+  loadWMOGroupsInternal(groupsPendingLoad, loadFactor) {
+    let count = 0;
+
+    for (const entryID of groupsPendingLoad.keys()) {
+      const wmo = this.wmos.get(entryID);
+
+      if (!wmo) {
+        continue;
+      }
+
+      const groupIndexes = groupsPendingLoad.get(entryID);
+
+      for (const groupIndex of groupIndexes.values()) {
+        this.loadWMOGroup(wmo, groupIndex);
+
+        groupIndexes.delete(groupIndex);
+
+        ++count;
+
+        if (count > this.groupsPendingLoadCount * loadFactor) {
+          return;
+        }
+      }
+
+      // We've loaded all groups for this root WMO entry.
+      if (groupIndexes.size === 0) {
+        groupsPendingLoad.delete(entryID);
+
+        // Now that groups are all accounted for, it's time to bring in the appropriate doodads.
+        const doodadsPendingLoad = new Set(wmo.doodadSetEntries(wmo.requestedDoodadSet));
+        this.doodadsPendingLoadCount += doodadsPendingLoad.size;
+        this.doodadsPendingLoad.set(entryID, doodadsPendingLoad);
+      }
+    }
+  }
+
+  loadWMOGroup(wmo, groupIndex) {
+    --this.groupsPendingLoadCount;
+    ++this.groupCount;
+
+    wmo.loadGroup(groupIndex);
+  }
+
+  loadWMODoodads() {
+    let count = 0;
+
+    for (const entryID of this.doodadsPendingLoad.keys()) {
+      const wmo = this.wmos.get(entryID);
+
+      if (!wmo) {
+        continue;
+      }
+
+      const doodadEntries = this.doodadsPendingLoad.get(entryID);
+
+      for (const doodadEntry of doodadEntries.values()) {
+        this.loadWMODoodad(wmo, doodadEntry);
+
+        doodadEntries.delete(doodadEntry);
+
+        ++count;
+
+        if (count > this.doodadsPendingLoadCount * this.constructor.DOODAD_LOAD_FACTOR) {
+          return;
+        }
+      }
+
+      // We've loaded all doodads for this root WMO entry.
+      if (doodadEntries.size === 0) {
+        this.doodadsPendingLoad.delete(entryID);
+      }
+    }
+  }
+
+  loadWMODoodad(wmo, entry) {
+    --this.doodadsPendingLoadCount;
+    ++this.doodadCount;
+
+    wmo.renderDoodad(entry);
+  }
+
+  // Every tick of the load interval, unload a portion of any root WMOs pending unload.
+  unloadWMOs() {
+    let count = 0;
+
+    for (const entry of this.entriesPendingUnload.values()) {
+      // If the root WMO was already unloaded, remove it from the pending unloads.
+      if (!this.wmos.has(entry.id)) {
+        this.entriesPendingUnload.delete(entry.id);
+        continue;
+      }
+
+      this.unloadWMO(entry);
+
+      this.entriesPendingUnload.delete(entry.id);
+
+      ++count;
+
+      if (count > this.entriesPendingUnload.size * this.constructor.LOAD_FACTOR) {
+        return;
+      }
+    }
+  }
+
+  unloadWMO(entry) {
+    const wmo = this.wmos.get(entry.id);
+    this.wmos.delete(entry.id);
+
+    this.groupCount -= wmo.groupCount;
+    this.doodadCount -= wmo.doodadSetEntries(wmo.requestedDoodadSet).length;
+
+    this.map.remove(wmo);
+  }
+
+  animate(delta, camera, cameraRotated) {
+  }
+
+}
+
+export default WMOManager;

--- a/src/lib/game/world/wmo-manager.js
+++ b/src/lib/game/world/wmo-manager.js
@@ -1,4 +1,3 @@
-import WMO from '../../pipeline/wmo';
 import WMOBlueprint from '../../pipeline/wmo/blueprint';
 import WMOGroupBlueprint from '../../pipeline/wmo/group/blueprint';
 

--- a/src/lib/pipeline/adt/chunk/index.js
+++ b/src/lib/pipeline/adt/chunk/index.js
@@ -107,6 +107,16 @@ class Chunk extends THREE.Mesh {
     return bit & this.holes;
   }
 
+  dispose() {
+    this.geometry.dispose();
+
+    this.material.textures.forEach((texture) => {
+      texture.dispose();
+    });
+
+    this.material.dispose();
+  }
+
   static chunkFor(position) {
     return 32 * 16 - (position / this.SIZE) | 0;
   }

--- a/src/lib/pipeline/adt/chunk/index.js
+++ b/src/lib/pipeline/adt/chunk/index.js
@@ -2,6 +2,7 @@ import THREE from 'three';
 
 import ADT from '../';
 import Material from './material';
+import TextureLoader from '../../texture-loader';
 
 class Chunk extends THREE.Mesh {
 
@@ -109,16 +110,15 @@ class Chunk extends THREE.Mesh {
 
   dispose() {
     this.geometry.dispose();
+    this.material.dispose();
 
     this.material.textures.forEach((texture) => {
-      texture.dispose();
+      TextureLoader.unload(texture.sourceFile);
     });
 
     this.material.alphaMaps.forEach((alphaMap) => {
       alphaMap.dispose();
     });
-
-    this.material.dispose();
   }
 
   static chunkFor(position) {

--- a/src/lib/pipeline/adt/chunk/index.js
+++ b/src/lib/pipeline/adt/chunk/index.js
@@ -114,6 +114,10 @@ class Chunk extends THREE.Mesh {
       texture.dispose();
     });
 
+    this.material.alphaMaps.forEach((alphaMap) => {
+      alphaMap.dispose();
+    });
+
     this.material.dispose();
   }
 

--- a/src/lib/pipeline/adt/chunk/index.js
+++ b/src/lib/pipeline/adt/chunk/index.js
@@ -11,6 +11,8 @@ class Chunk extends THREE.Mesh {
   constructor(adt, id) {
     super();
 
+    this.matrixAutoUpdate = false;
+
     const data = this.data = adt.data.MCNKs[id];
     const textureNames = adt.textures;
 

--- a/src/lib/pipeline/adt/chunk/index.js
+++ b/src/lib/pipeline/adt/chunk/index.js
@@ -2,7 +2,6 @@ import THREE from 'three';
 
 import ADT from '../';
 import Material from './material';
-import TextureLoader from '../../texture-loader';
 
 class Chunk extends THREE.Mesh {
 

--- a/src/lib/pipeline/adt/chunk/index.js
+++ b/src/lib/pipeline/adt/chunk/index.js
@@ -111,14 +111,6 @@ class Chunk extends THREE.Mesh {
   dispose() {
     this.geometry.dispose();
     this.material.dispose();
-
-    this.material.textures.forEach((texture) => {
-      TextureLoader.unload(texture.sourceFile);
-    });
-
-    this.material.alphaMaps.forEach((alphaMap) => {
-      alphaMap.dispose();
-    });
   }
 
   static chunkFor(position) {

--- a/src/lib/pipeline/adt/chunk/material.js
+++ b/src/lib/pipeline/adt/chunk/material.js
@@ -18,8 +18,14 @@ class Material extends THREE.ShaderMaterial {
 
     this.side = THREE.BackSide;
 
+    this.layerCount = 0;
+    this.textures = [];
+    this.alphaMaps = [];
+
+    this.loadLayers();
+
     this.uniforms = {
-      layerCount: { type: 'i', value: this.layers.length },
+      layerCount: { type: 'i', value: this.layerCount },
       alphaMaps: { type: 'tv', value: this.alphaMaps },
       textures: { type: 'tv', value: this.textures },
 
@@ -36,23 +42,40 @@ class Material extends THREE.ShaderMaterial {
     };
   }
 
-  get alphaMaps() {
-    return this.rawAlphaMaps.map((raw) => {
+  loadLayers() {
+    this.layerCount = this.layers.length;
+
+    this.loadAlphaMaps();
+    this.loadTextures();
+  }
+
+  loadAlphaMaps() {
+    const alphaMaps = [];
+
+    this.rawAlphaMaps.forEach((raw) => {
       const texture = new THREE.DataTexture(raw, 64, 64);
       texture.format = THREE.LuminanceFormat;
       texture.minFilter = texture.magFilter = THREE.LinearFilter;
       texture.needsUpdate = true;
-      return texture;
+
+      alphaMaps.push(texture);
     });
+
+    this.alphaMaps = alphaMaps;
   }
 
-  get textures() {
-    return this.layers.map((layer) => {
+  loadTextures() {
+    const textures = [];
+
+    this.layers.forEach((layer) => {
       const filename = this.textureNames[layer.textureID];
       const texture = TextureLoader.load(filename);
       texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
-      return texture;
+
+      textures.push(texture);
     });
+
+    this.textures = textures;
   }
 
 }

--- a/src/lib/pipeline/adt/chunk/material.js
+++ b/src/lib/pipeline/adt/chunk/material.js
@@ -78,6 +78,17 @@ class Material extends THREE.ShaderMaterial {
     this.textures = textures;
   }
 
+  dispose() {
+    super.dispose();
+
+    this.textures.forEach((texture) => {
+      TextureLoader.unload(texture.sourceFile);
+    });
+
+    this.alphaMaps.forEach((alphaMap) => {
+      alphaMap.dispose();
+    });
+  }
 }
 
 export default Material;

--- a/src/lib/pipeline/m2/animation-manager.js
+++ b/src/lib/pipeline/m2/animation-manager.js
@@ -97,7 +97,6 @@ class AnimationManager {
 
       clip.tracks.push(track);
 
-      clip.trim();
       clip.optimize();
     });
 

--- a/src/lib/pipeline/m2/blueprint.js
+++ b/src/lib/pipeline/m2/blueprint.js
@@ -12,8 +12,6 @@ class M2Blueprint {
   static UNLOAD_INTERVAL = 15000;
 
   static load(rawPath) {
-    window.m2bp = this;
-
     const path = rawPath.replace(/\.md(x|l)/i, '.m2').toUpperCase();
 
     // Prevent unintended unloading.

--- a/src/lib/pipeline/m2/blueprint.js
+++ b/src/lib/pipeline/m2/blueprint.js
@@ -1,0 +1,86 @@
+import WorkerPool from '../worker/pool';
+import M2 from './';
+
+class M2Blueprint {
+
+  static cache = new Map();
+
+  static references = new Map();
+  static pendingUnload = new Set();
+  static unloaderRunning = false;
+
+  static UNLOAD_INTERVAL = 15000;
+
+  static load(rawPath) {
+    window.m2bp = this;
+
+    const path = rawPath.replace(/\.md(x|l)/i, '.m2').toUpperCase();
+
+    // Prevent unintended unloading.
+    if (this.pendingUnload.has(path)) {
+      this.pendingUnload.delete(path);
+    }
+
+    // Background unloader might need to be started.
+    if (!this.unloaderRunning) {
+      this.unloaderRunning = true;
+      this.backgroundUnload();
+    }
+
+    // Keep track of references.
+    let refCount = this.references.get(path) || 0;
+    ++refCount;
+    this.references.set(path, refCount);
+
+    if (!this.cache.has(path)) {
+      this.cache.set(path, WorkerPool.enqueue('M2', path).then((args) => {
+        const [data, skinData] = args;
+
+        return new M2(path, data, skinData);
+      }));
+    }
+
+    return this.cache.get(path).then((m2) => {
+      return m2.clone();
+    });
+  }
+
+  static unload(m2) {
+    const path = m2.path.replace(/\.md(x|l)/i, '.m2').toUpperCase();
+
+    // Immediately dispose any non-instanced M2s.
+    if (!m2.canInstance) {
+      m2.dispose();
+    }
+
+    let refCount = this.references.get(path) || 1;
+
+    --refCount;
+
+    if (refCount === 0) {
+      this.pendingUnload.add(path);
+    } else {
+      this.references.set(path, refCount);
+    }
+  }
+
+  static backgroundUnload() {
+    this.pendingUnload.forEach((path) => {
+      // Handle disposal for instanced M2s.
+      if (this.cache.has(path)) {
+        this.cache.get(path).then((m2) => {
+          m2.dispose();
+        });
+      }
+
+      this.cache.delete(path);
+      this.references.delete(path);
+      this.pendingUnload.delete(path);
+    });
+
+    setTimeout(this.backgroundUnload.bind(this), this.UNLOAD_INTERVAL);
+  }
+
+}
+
+export default M2Blueprint;

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -4,6 +4,7 @@ import Submesh from './submesh';
 import M2Material from './material';
 import AnimationManager from './animation-manager';
 import WorkerPool from '../worker/pool';
+import TextureLoader from '../texture-loader';
 
 class M2 extends THREE.Group {
 
@@ -432,7 +433,7 @@ class M2 extends THREE.Group {
         child.material.dispose();
 
         child.material.textures.forEach((texture) => {
-          texture.dispose();
+          TextureLoader.unload(texture.sourceFile);
         });
       });
     });

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -3,8 +3,6 @@ import THREE from 'three';
 import Submesh from './submesh';
 import M2Material from './material';
 import AnimationManager from './animation-manager';
-import WorkerPool from '../worker/pool';
-import TextureLoader from '../texture-loader';
 
 class M2 extends THREE.Group {
 
@@ -431,10 +429,6 @@ class M2 extends THREE.Group {
       submesh.children.forEach((child) => {
         child.geometry.dispose();
         child.material.dispose();
-
-        child.material.textures.forEach((texture) => {
-          TextureLoader.unload(texture.sourceFile);
-        });
       });
     });
   }
@@ -451,19 +445,6 @@ class M2 extends THREE.Group {
     }
 
     return new this.constructor(this.path, this.data, this.skinData, instance);
-  }
-
-  static load(path) {
-    path = path.replace(/\.md(x|l)/i, '.m2');
-    if (!(path in this.cache)) {
-      this.cache[path] = WorkerPool.enqueue('M2', path).then((args) => {
-        const [data, skinData] = args;
-        return new this(path, data, skinData, null);
-      });
-    }
-    return this.cache[path].then((m2) => {
-      return m2.clone();
-    });
   }
 
 }

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -12,6 +12,8 @@ class M2 extends THREE.Group {
   constructor(path, data, skinData, instance = null) {
     super();
 
+    this.matrixAutoUpdate = false;
+
     this.name = path.split('\\').slice(-1).pop();
 
     this.path = path;
@@ -91,6 +93,7 @@ class M2 extends THREE.Group {
       // Enable skinning support on this M2 if we have bone animations.
       if (boneDef.animated) {
         this.useSkinning = true;
+        this.matrixAutoUpdate = true;
       }
 
       // Flag billboarded bones
@@ -150,6 +153,8 @@ class M2 extends THREE.Group {
 
     // Assemble the skeleton
     this.skeleton = new THREE.Skeleton(bones);
+
+    this.skeleton.matrixAutoUpdate = this.matrixAutoUpdate;
   }
 
   // Returns a map of M2Materials indexed by submesh. Each material represents a texture unit,
@@ -274,6 +279,8 @@ class M2 extends THREE.Group {
       mesh = new THREE.Mesh(geometry);
     }
 
+    mesh.matrixAutoUpdate = this.matrixAutoUpdate;
+
     // Add mesh to the group
     this.add(mesh);
 
@@ -353,7 +360,8 @@ class M2 extends THREE.Group {
       skeleton: this.skeleton,
       geometry: geometry,
       rootBone: rootBone,
-      useSkinning: this.useSkinning
+      useSkinning: this.useSkinning,
+      matrixAutoUpdate: this.matrixAutoUpdate
     };
 
     const submesh = new Submesh(opts);

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -93,7 +93,6 @@ class M2 extends THREE.Group {
       // Enable skinning support on this M2 if we have bone animations.
       if (boneDef.animated) {
         this.useSkinning = true;
-        this.matrixAutoUpdate = true;
       }
 
       // Flag billboarded bones

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -424,12 +424,7 @@ class M2 extends THREE.Group {
     this.mesh.geometry.dispose();
 
     this.submeshes.forEach((submesh) => {
-      submesh.geometry.dispose();
-
-      submesh.children.forEach((child) => {
-        child.geometry.dispose();
-        child.material.dispose();
-      });
+      submesh.dispose();
     });
   }
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -420,6 +420,24 @@ class M2 extends THREE.Group {
     }
   }
 
+  dispose() {
+    this.geometry.dispose();
+    this.mesh.geometry.dispose();
+
+    this.submeshes.forEach((submesh) => {
+      submesh.geometry.dispose();
+
+      submesh.children.forEach((child) => {
+        child.geometry.dispose();
+        child.material.dispose();
+
+        child.material.textures.forEach((texture) => {
+          texture.dispose();
+        });
+      });
+    });
+  }
+
   clone() {
     let instance = {};
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -111,8 +111,11 @@ class M2 extends THREE.Group {
           trackType: 'VectorKeyframeTrack',
 
           valueTransform: function(value) {
-            const translation = new THREE.Vector3(-value.x, -value.y, value.z);
-            return bone.position.clone().add(translation);
+            return new THREE.Vector3(
+              bone.position.x + -value.x,
+              bone.position.y + -value.y,
+              bone.position.z + value.z
+            );
           }
         });
       }
@@ -126,7 +129,7 @@ class M2 extends THREE.Group {
           trackType: 'QuaternionKeyframeTrack',
 
           valueTransform: function(value) {
-            return new THREE.Quaternion(value.x, value.y, -value.z, value.w).inverse();
+            return new THREE.Quaternion(value.x, value.y, -value.z, -value.w);
           }
         });
       }

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -254,6 +254,13 @@ class M2Material extends THREE.ShaderMaterial {
     this.loadTextures();
   }
 
+  dispose() {
+    super.dispose();
+
+    this.textures.forEach((texture) => {
+      TextureLoader.unload(texture.sourceFile);
+    });
+  }
 }
 
 export default M2Material;

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -61,6 +61,7 @@ class M2Material extends THREE.ShaderMaterial {
     this.skins.skin2 = null;
     this.skins.skin3 = null;
 
+    this.textures = [];
     this.textureDefs = def.textures;
     this.loadTextures();
   }
@@ -203,6 +204,8 @@ class M2Material extends THREE.ShaderMaterial {
     textureDefs.forEach((textureDef) => {
       textures.push(this.loadTexture(textureDef));
     });
+
+    this.textures = textures;
 
     // Update shader uniforms to reflect loaded textures.
     this.uniforms.textures = { type: 'tv', value: textures };

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -96,6 +96,15 @@ class Submesh extends THREE.Group {
     }
   }
 
+  dispose() {
+    this.geometry.dispose();
+
+    this.children.forEach((child) => {
+      child.geometry.dispose();
+      child.material.dispose();
+    });
+  }
+
 }
 
 export default Submesh;

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -5,6 +5,8 @@ class Submesh extends THREE.Group {
   constructor(opts) {
     super();
 
+    this.matrixAutoUpdate = opts.matrixAutoUpdate;
+
     this.useSkinning = opts.useSkinning;
 
     this.rootBone = null;
@@ -53,6 +55,8 @@ class Submesh extends THREE.Group {
       } else {
         tuMesh = new THREE.Mesh(this.geometry, tuMaterial);
       }
+
+      tuMesh.matrixAutoUpdate = this.matrixAutoUpdate;
 
       this.add(tuMesh);
     }

--- a/src/lib/pipeline/texture-loader.js
+++ b/src/lib/pipeline/texture-loader.js
@@ -4,17 +4,70 @@ const loader = new THREE.TextureLoader();
 
 class TextureLoader {
 
-  static cache = {};
+  static cache = new Map();
+  static references = new Map();
+  static pendingUnload = new Set();
+  static unloaderRunning = false;
 
-  static load(path) {
-    const encodedPath = encodeURI(`pipeline/${path}.png`);
-    if (!(path in this.cache)) {
-      // TODO: Promisify THREE's TextureLoader callbacks
-      this.cache[path] = loader.load(encodedPath, function(texture) {
-        texture.needsUpdate = true;
-      });
+  static UNLOAD_INTERVAL = 15000;
+
+  static load(rawPath) {
+    const path = rawPath.toUpperCase();
+
+    // Prevent unintended unloading.
+    if (this.pendingUnload.has(path)) {
+      this.pendingUnload.delete(path);
     }
-    return this.cache[path];
+
+    // Background unloader might need to be started.
+    if (!this.unloaderRunning) {
+      this.unloaderRunning = true;
+      this.backgroundUnload();
+    }
+
+    // Keep track of references.
+    let refCount = this.references.get(path) || 0;
+    ++refCount;
+    this.references.set(path, refCount);
+
+    const encodedPath = encodeURI(`pipeline/${path}.png`);
+
+    if (!this.cache.has(path)) {
+      // TODO: Promisify THREE's TextureLoader callbacks
+      this.cache.set(path, loader.load(encodedPath, function(texture) {
+        texture.sourceFile = path;
+        texture.needsUpdate = true;
+      }));
+    }
+
+    return this.cache.get(path);
+  }
+
+  static unload(rawPath) {
+    const path = rawPath.toUpperCase();
+
+    let refCount = this.references.get(path) || 1;
+    --refCount;
+
+    if (refCount === 0) {
+      this.pendingUnload.add(path);
+    } else {
+      this.references.set(path, refCount);
+    }
+  }
+
+  static backgroundUnload() {
+    this.pendingUnload.forEach((path) => {
+      if (this.cache.has(path)) {
+        this.cache.get(path).dispose();
+      }
+
+      this.cache.delete(path);
+      this.references.delete(path);
+      this.pendingUnload.delete(path);
+    });
+
+    setTimeout(this.backgroundUnload.bind(this), this.UNLOAD_INTERVAL);
   }
 
 }

--- a/src/lib/pipeline/wmo/blueprint.js
+++ b/src/lib/pipeline/wmo/blueprint.js
@@ -1,0 +1,72 @@
+import WorkerPool from '../worker/pool';
+import WMO from './';
+
+class WMOBlueprint {
+
+  static cache = new Map();
+
+  static references = new Map();
+  static pendingUnload = new Set();
+  static unloaderRunning = false;
+
+  static UNLOAD_INTERVAL = 15000;
+
+  static load(rawPath) {
+    const path = rawPath.toUpperCase();
+
+    // Prevent unintended unloading.
+    if (this.pendingUnload.has(path)) {
+      this.pendingUnload.delete(path);
+    }
+
+    // Background unloader might need to be started.
+    if (!this.unloaderRunning) {
+      this.unloaderRunning = true;
+      this.backgroundUnload();
+    }
+
+    // Keep track of references.
+    let refCount = this.references.get(path) || 0;
+    ++refCount;
+    this.references.set(path, refCount);
+
+    if (!this.cache.has(path)) {
+      this.cache.set(path, WorkerPool.enqueue('WMO', path).then((args) => {
+        const [data] = args;
+
+        return new WMO(path, data);
+      }));
+    }
+
+    return this.cache.get(path).then((wmo) => {
+      return wmo.clone();
+    });
+  }
+
+  static unload(wmo) {
+    const path = wmo.path.toUpperCase();
+
+    let refCount = this.references.get(path) || 1;
+
+    --refCount;
+
+    if (refCount === 0) {
+      this.pendingUnload.add(path);
+    } else {
+      this.references.set(path, refCount);
+    }
+  }
+
+  static backgroundUnload() {
+    this.pendingUnload.forEach((path) => {
+      this.cache.delete(path);
+      this.references.delete(path);
+      this.pendingUnload.delete(path);
+    });
+
+    setTimeout(this.backgroundUnload.bind(this), this.UNLOAD_INTERVAL);
+  }
+
+}
+
+export default WMOBlueprint;

--- a/src/lib/pipeline/wmo/group/blueprint.js
+++ b/src/lib/pipeline/wmo/group/blueprint.js
@@ -1,0 +1,86 @@
+import WorkerPool from '../../worker/pool';
+import WMOGroup from './';
+
+class WMOGroupBlueprint {
+
+  static cache = new Map();
+
+  static references = new Map();
+  static pendingUnload = new Set();
+  static unloaderRunning = false;
+
+  static UNLOAD_INTERVAL = 15000;
+
+  static load(wmo, rawPath) {
+    const path = rawPath.toUpperCase();
+
+    // Prevent unintended unloading.
+    if (this.pendingUnload.has(path)) {
+      this.pendingUnload.delete(path);
+    }
+
+    // Background unloader might need to be started.
+    if (!this.unloaderRunning) {
+      this.unloaderRunning = true;
+      this.backgroundUnload();
+    }
+
+    // Keep track of references.
+    let refCount = this.references.get(path) || 0;
+    ++refCount;
+    this.references.set(path, refCount);
+
+    if (!this.cache.has(path)) {
+      this.cache.set(path, WorkerPool.enqueue('WMOGroup', path).then((args) => {
+        const [data] = args;
+
+        return new WMOGroup(wmo, path, data);
+      }));
+    }
+
+    return this.cache.get(path).then((wmoGroup) => {
+      return wmoGroup.clone();
+    });
+  }
+
+  static loadWithID(wmo, path, id) {
+    const suffix = `000${id}`.slice(-3);
+    const groupPath = path.replace(/\.wmo/i, `_${suffix}.wmo`);
+
+    return this.load(wmo, groupPath);
+  }
+
+  static unload(wmoGroup) {
+    wmoGroup.dispose();
+
+    const path = wmoGroup.path.toUpperCase();
+
+    let refCount = this.references.get(path) || 1;
+    --refCount;
+
+    if (refCount === 0) {
+      this.pendingUnload.add(path);
+    } else {
+      this.references.set(path, refCount);
+    }
+  }
+
+  static backgroundUnload() {
+    this.pendingUnload.forEach((path) => {
+      if (this.cache.has(path)) {
+        this.cache.get(path).then((wmoGroup) => {
+          wmoGroup.dispose();
+        });
+      }
+
+      this.cache.delete(path);
+      this.references.delete(path);
+      this.pendingUnload.delete(path);
+    });
+
+    setTimeout(this.backgroundUnload.bind(this), this.UNLOAD_INTERVAL);
+  }
+
+}
+
+export default WMOGroupBlueprint;

--- a/src/lib/pipeline/wmo/group/index.js
+++ b/src/lib/pipeline/wmo/group/index.js
@@ -1,6 +1,6 @@
 import THREE from 'three';
 
-import M2 from '../../m2';
+import M2Blueprint from '../../m2/blueprint';
 import WorkerPool from '../../worker/pool';
 
 class WMOGroup extends THREE.Mesh {
@@ -15,6 +15,8 @@ class WMOGroup extends THREE.Mesh {
     this.data = data;
 
     this.indoor = data.indoor;
+
+    this.doodads = new Set();
 
     const vertexCount = data.MOVT.vertices.length;
     const textureCoords = data.MOTV.textureCoords;
@@ -92,7 +94,7 @@ class WMOGroup extends THREE.Mesh {
   loadDoodad(entry) {
     ++this.parent.loadedDoodadCount;
 
-    M2.load(entry.filename).then((m2) => {
+    M2Blueprint.load(entry.filename).then((m2) => {
       m2.position.set(
         -entry.position.x,
         -entry.position.y,
@@ -108,6 +110,15 @@ class WMOGroup extends THREE.Mesh {
 
       this.add(m2);
       m2.updateMatrix();
+
+      this.doodads.add(m2);
+    });
+  }
+
+  unloadDoodads() {
+    this.doodads.forEach((m2) => {
+      M2Blueprint.unload(m2);
+      this.doodads.delete(m2);
     });
   }
 

--- a/src/lib/pipeline/wmo/group/index.js
+++ b/src/lib/pipeline/wmo/group/index.js
@@ -1,5 +1,6 @@
 import THREE from 'three';
 
+import M2 from '../../m2';
 import WorkerPool from '../../worker/pool';
 
 class WMOGroup extends THREE.Mesh {
@@ -86,6 +87,28 @@ class WMOGroup extends THREE.Mesh {
     });
 
     this.materialIDs = materialIDs;
+  }
+
+  loadDoodad(entry) {
+    ++this.parent.loadedDoodadCount;
+
+    M2.load(entry.filename).then((m2) => {
+      m2.position.set(
+        -entry.position.x,
+        -entry.position.y,
+        entry.position.z
+      );
+
+      // Adjust M2 rotation to match Wowser's axes.
+      const quat = m2.quaternion;
+      quat.set(entry.rotation.x, entry.rotation.y, -entry.rotation.z, -entry.rotation.w);
+
+      const scale = entry.scale;
+      m2.scale.set(scale, scale, scale);
+
+      this.add(m2);
+      m2.updateMatrix();
+    });
   }
 
   clone() {

--- a/src/lib/pipeline/wmo/group/index.js
+++ b/src/lib/pipeline/wmo/group/index.js
@@ -9,6 +9,8 @@ class WMOGroup extends THREE.Mesh {
   constructor(data) {
     super();
 
+    this.matrixAutoUpdate = false;
+
     this.data = data;
 
     this.indoor = data.indoor;

--- a/src/lib/pipeline/wmo/index.js
+++ b/src/lib/pipeline/wmo/index.js
@@ -1,8 +1,6 @@
 import THREE from 'three';
 
-import Group from './group';
-import WMOMaterial from './material';
-import WorkerPool from '../worker/pool';
+import WMOGroupBlueprint from './group/blueprint';
 
 class WMO extends THREE.Group {
 
@@ -44,69 +42,18 @@ class WMO extends THREE.Group {
   }
 
   loadGroup(index) {
-    return Group.loadWithID(this.path, index).then((group) => {
+    return WMOGroupBlueprint.loadWithID(this, this.path, index).then((group) => {
+      this.renderGroup(group);
+
       this.groups.set(index, group);
-
-      const materialDefs = this.data.MOMT.materials;
-      const texturePaths = this.data.MOTX.filenames;
-
-      this.renderGroup(group, materialDefs, texturePaths);
 
       return group;
     });
   }
 
-  createMaterial(materialDef, texturePaths) {
-    const textureDefs = [];
-
-    materialDef.textures.forEach((textureDef) => {
-      const texturePath = texturePaths[textureDef.offset];
-
-      if (texturePath !== undefined) {
-        textureDef.path = texturePath;
-        textureDefs.push(textureDef);
-      } else {
-        textureDefs.push(null);
-      }
-    });
-
-    const material = new WMOMaterial(materialDef, textureDefs);
-
-    return material;
-  }
-
-  renderGroup(group, materialDefs, texturePaths) {
+  renderGroup(group) {
     ++this.loadedGroupCount;
 
-    // Obtain materials used in group. Can't recycle materials, as indoor/outdoor shading modes are
-    // assigned per group, but materials may be shared across multiple groups with different
-    // indoor/outdoor flags each use.
-    const groupMaterial = new THREE.MultiMaterial();
-
-    group.materialIDs.forEach((materialID) => {
-      const materialDef = materialDefs[materialID];
-
-      if (group.indoor) {
-        materialDef.indoor = true;
-      } else {
-        materialDef.indoor = false;
-      }
-
-      if (!this.data.MOHD.skipBaseColor) {
-        materialDef.useBaseColor = true;
-        materialDef.baseColor = this.data.MOHD.baseColor;
-      } else {
-        materialDef.useBaseColor = false;
-      }
-
-      const material = this.createMaterial(materialDefs[materialID], texturePaths);
-
-      groupMaterial.materials[materialID] = material;
-    });
-
-    group.material = groupMaterial;
-
-    // Finally, add the group to the WMO.
     this.add(group);
     group.updateMatrix();
   }
@@ -128,30 +75,8 @@ class WMO extends THREE.Group {
     });
   }
 
-  dispose() {
-    this.groups.forEach((group) => {
-      group.geometry.dispose();
-
-      group.material.materials.forEach((material) => {
-        material.dispose();
-      });
-    });
-  }
-
   clone() {
     return new this.constructor(this.path, this.data);
-  }
-
-  static load(path) {
-    if (!(path in this.cache)) {
-      this.cache[path] = WorkerPool.enqueue('WMO', path).then((args) => {
-        const [data] = args;
-        return new this(path, data);
-      });
-    }
-    return this.cache[path].then((wmo) => {
-      return wmo.clone();
-    });
   }
 
 }

--- a/src/lib/pipeline/wmo/index.js
+++ b/src/lib/pipeline/wmo/index.js
@@ -12,6 +12,8 @@ class WMO extends THREE.Group {
   constructor(path, data) {
     super();
 
+    this.matrixAutoUpdate = false;
+
     this.path = path;
     this.data = data;
 
@@ -75,6 +77,7 @@ class WMO extends THREE.Group {
 
     // Finally, add the group to the WMO.
     this.add(group);
+    group.updateMatrix();
   }
 
   set doodadSet(doodadSet) {
@@ -102,6 +105,7 @@ class WMO extends THREE.Group {
         m2.scale.set(scale, scale, scale);
 
         this.add(m2);
+        m2.updateMatrix();
       });
     });
   }

--- a/src/lib/pipeline/wmo/index.js
+++ b/src/lib/pipeline/wmo/index.js
@@ -128,6 +128,16 @@ class WMO extends THREE.Group {
     });
   }
 
+  dispose() {
+    this.groups.forEach((group) => {
+      group.geometry.dispose();
+
+      group.material.materials.forEach((material) => {
+        material.dispose();
+      });
+    });
+  }
+
   clone() {
     return new this.constructor(this.path, this.data);
   }

--- a/src/lib/pipeline/wmo/index.js
+++ b/src/lib/pipeline/wmo/index.js
@@ -2,7 +2,6 @@ import THREE from 'three';
 
 import Group from './group';
 import WMOMaterial from './material';
-import M2 from '../m2';
 import WorkerPool from '../worker/pool';
 
 class WMO extends THREE.Group {
@@ -20,6 +19,7 @@ class WMO extends THREE.Group {
     this.loadedGroupCount = 0;
     this.loadedDoodadCount = 0;
 
+    this.groups = new Map();
     this.groupCount = data.MOHD.groupCount;
     this.indoorGroupIndices = [];
     this.outdoorGroupIndices = [];
@@ -44,11 +44,15 @@ class WMO extends THREE.Group {
   }
 
   loadGroup(index) {
-    Group.loadWithID(this.path, index).then((group) => {
+    return Group.loadWithID(this.path, index).then((group) => {
+      this.groups.set(index, group);
+
       const materialDefs = this.data.MOMT.materials;
       const texturePaths = this.data.MOTX.filenames;
 
       this.renderGroup(group, materialDefs, texturePaths);
+
+      return group;
     });
   }
 
@@ -121,28 +125,6 @@ class WMO extends THREE.Group {
 
     entries.forEach((entry) => {
       this.renderDoodad(entry);
-    });
-  }
-
-  renderDoodad(entry) {
-    ++this.loadedDoodadCount;
-
-    M2.load(entry.filename).then((m2) => {
-      m2.position.set(
-        -entry.position.x,
-        -entry.position.y,
-        entry.position.z
-      );
-
-      // Adjust M2 rotation to match Wowser's axes.
-      const quat = m2.quaternion;
-      quat.set(entry.rotation.x, entry.rotation.y, -entry.rotation.z, -entry.rotation.w);
-
-      const scale = entry.scale;
-      m2.scale.set(scale, scale, scale);
-
-      this.add(m2);
-      m2.updateMatrix();
     });
   }
 

--- a/src/lib/pipeline/wmo/index.js
+++ b/src/lib/pipeline/wmo/index.js
@@ -17,6 +17,9 @@ class WMO extends THREE.Group {
     this.path = path;
     this.data = data;
 
+    this.loadedGroupCount = 0;
+    this.loadedDoodadCount = 0;
+
     this.groupCount = data.MOHD.groupCount;
     this.indoorGroupIndices = [];
     this.outdoorGroupIndices = [];
@@ -69,6 +72,8 @@ class WMO extends THREE.Group {
   }
 
   renderGroup(group, materialDefs, texturePaths) {
+    ++this.loadedGroupCount;
+
     // Obtain materials used in group. Can't recycle materials, as indoor/outdoor shading modes are
     // assigned per group, but materials may be shared across multiple groups with different
     // indoor/outdoor flags each use.
@@ -120,6 +125,8 @@ class WMO extends THREE.Group {
   }
 
   renderDoodad(entry) {
+    ++this.loadedDoodadCount;
+
     M2.load(entry.filename).then((m2) => {
       m2.position.set(
         -entry.position.x,

--- a/src/lib/pipeline/wmo/material/index.js
+++ b/src/lib/pipeline/wmo/material/index.js
@@ -9,6 +9,8 @@ class WMOMaterial extends THREE.ShaderMaterial {
   constructor(def, textureDefs) {
     super();
 
+    this.textures = [];
+
     this.uniforms = {
       textures: { type: 'tv', value: [] },
       textureCount: { type: 'i', value: 0 },
@@ -98,11 +100,20 @@ class WMOMaterial extends THREE.ShaderMaterial {
       }
     });
 
+    this.textures = textures;
+
     // Update shader uniforms to reflect loaded textures.
     this.uniforms.textures = { type: 'tv', value: textures };
     this.uniforms.textureCount = { type: 'i', value: textures.length };
   }
 
+  dispose() {
+    super.dispose();
+
+    this.textures.forEach((texture) => {
+      TextureLoader.unload(texture.sourceFile);
+    });
+  }
 }
 
 export default WMOMaterial;


### PR DESCRIPTION
* Terrain, doodad, and WMO managers are now used to gracefully add and remove map chunk content to and from the map.

* Rather than attempting to load everything as fast as possible (the current behavior), smaller portions of doodads, WMOs, WMO groups, and WMO doodads are loaded via the managers at configurable intervals. The same holds true for unloading.

* WMO groups are loaded outdoor-first, to minimize the chance for visible pop-in when approaching large WMOs such as capital cities.

* When map doodads and WMOs are no longer referenced by the set of loaded map chunks, they are removed from the map. Large WMOs are unloaded on a timed delay, to prevent excessive loading and unloading when chunk boundaries are crossed.

* WMO doodads are now added to their relevant WMO group, and being to load after the group has loaded.

* ```matrixAutoUpdate``` has been set to false for all core 3D classes in Wowser. Instead, manual calls to ```updateMatrix()``` are made at appropriate times. This has significantly reduced the amount of matrix multiplication occurring during the render loop, which, in turn has improved framerates.

* Geometries, materials, and textures now get THREE.js ```dipose()``` calls, which triggers removal of various data from the ```WebGLRenderer``` (and, in turn, the GPU).

* ```M2```s, ```WMO```s, ```WMOGroup```s, and ```Texture```s are now managed by blueprint classes. The blueprint classes track references to every ```M2```, ```WMO```, ```WMOGroup```, and ```Texture```, and ensure that each is disposed of and removed from the relevant Wowser cache when appropriate.