### PR TITLE
Fix: Texture settings

### DIFF
--- a/src/lib/pipeline/adt/chunk/material.js
+++ b/src/lib/pipeline/adt/chunk/material.js
@@ -70,7 +70,6 @@ class Material extends THREE.ShaderMaterial {
     this.layers.forEach((layer) => {
       const filename = this.textureNames[layer.textureID];
       const texture = TextureLoader.load(filename);
-      texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
 
       textures.push(texture);
     });
@@ -82,7 +81,7 @@ class Material extends THREE.ShaderMaterial {
     super.dispose();
 
     this.textures.forEach((texture) => {
-      TextureLoader.unload(texture.sourceFile);
+      TextureLoader.unload(texture);
     });
 
     this.alphaMaps.forEach((alphaMap) => {

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -213,37 +213,45 @@ class M2Material extends THREE.ShaderMaterial {
   }
 
   loadTexture(textureDef) {
-    let loaded = null;
-
     const wrapS = THREE.RepeatWrapping;
     const wrapT = THREE.RepeatWrapping;
     const flipY = false;
 
+    let path = null;
+
     switch (textureDef.type) {
       case 0:
         // Hardcoded texture
-        loaded = TextureLoader.load(textureDef.filename, wrapS, wrapT, flipY);
+        path = textureDef.filename;
         break;
+
       case 11:
         if (this.skins.skin1) {
-          loaded = TextureLoader.load(this.skins.skin1, wrapS, wrapT, flipY);
+          path = this.skins.skin1;
         }
         break;
+
       case 12:
         if (this.skins.skin2) {
-          loaded = TextureLoader.load(this.skins.skin2, wrapS, wrapT, flipY);
+          path = this.skins.skin2;
         }
         break;
+
       case 13:
         if (this.skins.skin3) {
-          loaded = TextureLoader.load(this.skins.skin3, wrapS, wrapT, flipY);
+          path = this.skins.skin3;
         }
         break;
+
       default:
         break;
     }
 
-    return loaded;
+    if (path) {
+      return TextureLoader.load(path, wrapS, wrapT, flipY);
+    } else {
+      return null;
+    }
   }
 
   updateSkinTextures(skin1, skin2, skin3) {

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -219,24 +219,20 @@ class M2Material extends THREE.ShaderMaterial {
       case 0:
         // Hardcoded texture
         loaded = TextureLoader.load(textureDef.filename);
-        loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
         break;
       case 11:
         if (this.skins.skin1) {
           loaded = TextureLoader.load(this.skins.skin1);
-          loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
         }
         break;
       case 12:
         if (this.skins.skin2) {
           loaded = TextureLoader.load(this.skins.skin2);
-          loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
         }
         break;
       case 13:
         if (this.skins.skin3) {
           loaded = TextureLoader.load(this.skins.skin3);
-          loaded.wrapS = loaded.wrapT = THREE.RepeatWrapping;
         }
         break;
       default:
@@ -258,7 +254,7 @@ class M2Material extends THREE.ShaderMaterial {
     super.dispose();
 
     this.textures.forEach((texture) => {
-      TextureLoader.unload(texture.sourceFile);
+      TextureLoader.unload(texture);
     });
   }
 }

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -215,24 +215,28 @@ class M2Material extends THREE.ShaderMaterial {
   loadTexture(textureDef) {
     let loaded = null;
 
+    const wrapS = THREE.RepeatWrapping;
+    const wrapT = THREE.RepeatWrapping;
+    const flipY = false;
+
     switch (textureDef.type) {
       case 0:
         // Hardcoded texture
-        loaded = TextureLoader.load(textureDef.filename);
+        loaded = TextureLoader.load(textureDef.filename, wrapS, wrapT, flipY);
         break;
       case 11:
         if (this.skins.skin1) {
-          loaded = TextureLoader.load(this.skins.skin1);
+          loaded = TextureLoader.load(this.skins.skin1, wrapS, wrapT, flipY);
         }
         break;
       case 12:
         if (this.skins.skin2) {
-          loaded = TextureLoader.load(this.skins.skin2);
+          loaded = TextureLoader.load(this.skins.skin2, wrapS, wrapT, flipY);
         }
         break;
       case 13:
         if (this.skins.skin3) {
-          loaded = TextureLoader.load(this.skins.skin3);
+          loaded = TextureLoader.load(this.skins.skin3, wrapS, wrapT, flipY);
         }
         break;
       default:

--- a/src/lib/pipeline/m2/material/shader.vert
+++ b/src/lib/pipeline/m2/material/shader.vert
@@ -56,8 +56,8 @@ uniform float billboarded;
 void main() {
   // For some reason, V is inverted?!
   // TODO: Use vertexShaderMode to determine coordinates
-  texture1Coord = vec2(uv[0], -uv[1]);
-  texture2Coord = vec2(uv[0], -uv[1]);
+  texture1Coord = vec2(uv[0], uv[1]);
+  texture2Coord = vec2(uv[0], uv[1]);
 
   // TODO: Will this be needed in the fragment shader at some point?
   vec3 vertexWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;

--- a/src/lib/pipeline/wmo/material/index.js
+++ b/src/lib/pipeline/wmo/material/index.js
@@ -90,12 +90,7 @@ class WMOMaterial extends THREE.ShaderMaterial {
 
     textureDefs.forEach((textureDef) => {
       if (textureDef !== null) {
-        const texture = TextureLoader.load(textureDef.path);
-
-        texture.flipY = false;
-        texture.wrapS = this.wrapping;
-        texture.wrapT = this.wrapping;
-
+        const texture = TextureLoader.load(textureDef.path, this.wrapping, this.wrapping, false);
         textures.push(texture);
       }
     });
@@ -111,7 +106,7 @@ class WMOMaterial extends THREE.ShaderMaterial {
     super.dispose();
 
     this.textures.forEach((texture) => {
-      TextureLoader.unload(texture.sourceFile);
+      TextureLoader.unload(texture);
     });
   }
 }


### PR DESCRIPTION
This fixes a few issues with how textures are handled in Wowser. See issue #106 for an example of what's fixed.

**M2Material should have flipY set to false on its textures**
```WMOMaterial``` disables ```flipY```, but ```M2Material``` doesn't disable it. Instead, ```M2Material``` is doing this in its shader:
```
texture1Coord = vec2(uv[0], -uv[1]);
texture2Coord = vec2(uv[0], -uv[1]);
```
This is fairly pointless, since just setting ```flipY``` to false a la ```WMOMaterial``` prevents the need to do the negation in the shader.

This is now fixed, and ```flipY``` is set to false for ```M2Material``` (matching ```WMOMaterial```).

**Textures should be cached and loaded based on texture settings**
Currently, the ```TextureLoader``` assumes that, for a given texture path, it will always be used with the same settings (```wrapS```, ```wrapT```, ```flipY```, etc). This isn't necessarily true, since texture settings are defined in the WMO and M2 data files, and some (probably many) textures are reused between various models.

This is now fixed, and differing settings for ```wrapS```, ```wrapT```, and ```flipY``` result in unique textures being loaded and cached.