### PR TITLE
Fix: Added default texture to ADT chunk alpha maps

### DIFF
--- a/src/lib/pipeline/adt/chunk/material.js
+++ b/src/lib/pipeline/adt/chunk/material.js
@@ -61,6 +61,11 @@ class Material extends THREE.ShaderMaterial {
       alphaMaps.push(texture);
     });
 
+    // Texture array uniforms must have at least one value present to be considered valid.
+    if (alphaMaps.length === 0) {
+      alphaMaps.push(new THREE.Texture());
+    }
+
     this.alphaMaps = alphaMaps;
   }
 


### PR DESCRIPTION
Texture array uniforms need to contain at least one value or WebGL
prevents loading the uniform and emits an error. ADT chunk alpha maps,
in some cases, may have zero values (such as when the terrain only
has a base texture, and no layers).

This fixes the issue by adding a default texture to ADT chunk alpha
maps in the event no alpha maps were defined in the chunk's MCAL.

Closes #114.