### PR TITLE
Extract realm build info when provided

### DIFF
--- a/src/lib/realms/handler.js
+++ b/src/lib/realms/handler.js
@@ -54,6 +54,14 @@ class RealmsHandler extends EventEmitter {
       realm.timezone = ap.readUnsignedByte();
       realm.id = ap.readUnsignedByte();
 
+      // TODO: Introduce magic constants such as REALM_FLAG_SPECIFYBUILD
+      if (realm.flags & 0x04) {
+        realm.majorVersion = ap.readUnsignedByte();
+        realm.minorVersion = ap.readUnsignedByte();
+        realm.patchVersion = ap.readUnsignedByte();
+        realm.build = ap.readUnsignedShort();
+      }
+
       this.list.push(realm);
     }
 

--- a/src/lib/realms/realm.js
+++ b/src/lib/realms/realm.js
@@ -16,6 +16,11 @@ class Realm {
     this.timezone = null;
     this.population = 0.0;
     this.characters = 0;
+
+    this.majorVersion = null;
+    this.minorVersion = null;
+    this.patchVersion = null;
+    this.build = null;
   }
 
   // Short string representation of this realm


### PR DESCRIPTION
Not extracting this information will cause additional realms to be decoded incorrectly, potentially crashing and breaking the realm list in its entirety.

Works for a TrinityCore server, haven't tested this against ArcEmu yet.