### PR TITLE
Enforce border-style for dividers

### DIFF
--- a/src/components/wowser/ui/frame/dividers/index.styl
+++ b/src/components/wowser/ui/frame/dividers/index.styl
@@ -1,4 +1,5 @@
 wowser .divider
+  border-style: solid
 
   &, &.horizontal
     border-width: 3px 5px 0 5px


### PR DESCRIPTION
This makes sure the yellow frame dividers actually show in Firefox – possibly other browsers, too.

**Before**

![screen shot 2016-03-06 at 16 36 05](https://cloud.githubusercontent.com/assets/378235/13555178/90f195b8-e3b9-11e5-847e-95466832cf66.png)

**After**

![screen shot 2016-03-06 at 16 30 33](https://cloud.githubusercontent.com/assets/378235/13555162/3e0c4776-e3b9-11e5-8f8d-a1d3892a3696.png)
