### PR TITLE
Feature: M2 sequences

### DIFF
--- a/src/lib/game/unit.js
+++ b/src/lib/game/unit.js
@@ -82,7 +82,8 @@ class Unit extends Entity {
     // Auto-play animation index 0 in unit model, if present
     // TODO: Properly manage unit animations
     if (m2.animated && m2.animations.length > 0) {
-      m2.animations.play(0);
+      m2.animations.playAnimation(0);
+      m2.animations.playAllSequences();
     }
 
     this.emit('model:change', this, this._model, m2);

--- a/src/lib/game/world/doodad-manager.js
+++ b/src/lib/game/world/doodad-manager.js
@@ -138,7 +138,8 @@ class DoodadManager {
     // Auto-play animation index 0 in doodad, if animations are present.
     // TODO: Properly manage doodad animations.
     if (doodad.animations.length > 0) {
-      doodad.animations.play(0);
+      doodad.animations.playAnimation(0);
+      doodad.animations.playAllSequences();
     }
   }
 

--- a/src/lib/game/world/wmo-manager/wmo-handler.js
+++ b/src/lib/game/world/wmo-manager/wmo-handler.js
@@ -191,10 +191,13 @@ class WMOHandler {
     this.placeDoodad(wmoDoodadEntry, wmoDoodad);
 
     if (wmoDoodad.animated) {
-      // TODO: Do WMO doodads have more than one animation? If so, which one should play?
-      wmoDoodad.animations.play(0);
-
       this.animatedDoodads.set(wmoDoodadEntry.id, wmoDoodad);
+
+      if (wmoDoodad.animations.length > 0) {
+        // TODO: Do WMO doodads have more than one animation? If so, which one should play?
+        wmoDoodad.animations.playAnimation(0);
+        wmoDoodad.animations.playAllSequences();
+      }
     }
 
     this.doodads.set(wmoDoodadEntry.id, wmoDoodad);

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -50,7 +50,7 @@ class M2 extends THREE.Group {
       // time deltas. Instead, only the original M2 should receive time deltas.
       this.receivesAnimationUpdates = false;
     } else {
-      this.animations = new AnimationManager(this, data.animations);
+      this.animations = new AnimationManager(this, data.animations, data.sequences);
 
       if (this.animated) {
         this.receivesAnimationUpdates = true;


### PR DESCRIPTION
Additional groundwork for texture animations.

Please note that this PR includes commits from #126. We should ensure that PR is merged before tackling this PR.

Many (possibly even most) texture animations are part of global sequences rather than being set up as traditional animations. This PR adds support for global sequences to the M2 animation manager.