### PR TITLE
Feature: M2 texture animations

### DIFF
--- a/src/lib/pipeline/m2/animation-manager.js
+++ b/src/lib/pipeline/m2/animation-manager.js
@@ -1,9 +1,14 @@
+import EventEmitter from 'events';
 import THREE from 'three';
 
-class AnimationManager {
+class AnimationManager extends EventEmitter {
 
   constructor(root, animationDefs, sequenceDefs) {
-    this.animationDefs = animationDefs;
+    super();
+
+    // Complicated M2s may have far more than 10 (default listener cap) M2Materials subscribed to
+    // the same texture animations.
+    this.setMaxListeners(200);
 
     this.animationDefs = animationDefs;
     this.sequenceDefs = sequenceDefs;
@@ -26,6 +31,8 @@ class AnimationManager {
 
   update(delta) {
     this.mixer.update(delta);
+
+    this.emit('update');
   }
 
   playAnimation(animationIndex) {

--- a/src/lib/pipeline/m2/animation-manager.js
+++ b/src/lib/pipeline/m2/animation-manager.js
@@ -8,7 +8,7 @@ class AnimationManager extends EventEmitter {
 
     // Complicated M2s may have far more than 10 (default listener cap) M2Materials subscribed to
     // the same texture animations.
-    this.setMaxListeners(200);
+    this.setMaxListeners(150);
 
     this.animationDefs = animationDefs;
     this.sequenceDefs = sequenceDefs;

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -13,6 +13,8 @@ class M2 extends THREE.Group {
 
     this.matrixAutoUpdate = false;
 
+    this.eventListeners = [];
+
     this.name = path.split('\\').slice(-1).pop();
 
     this.path = path;
@@ -448,7 +450,7 @@ class M2 extends THREE.Group {
 
       // Set up event subscription to produce matrix from translation, rotation, and scaling
       // values.
-      this.animations.on('update', () => {
+      const updater = () => {
         const animationValue = this.uvAnimationValues[index];
 
         // Set up matrix for use in uv transform in vertex shader.
@@ -457,7 +459,11 @@ class M2 extends THREE.Group {
           animationValue.rotation,
           animationValue.scaling
         );
-      });
+      };
+
+      this.animations.on('update', updater);
+
+      this.eventListeners.push([this.animations, 'update', updater]);
     });
   }
 
@@ -605,7 +611,17 @@ class M2 extends THREE.Group {
     }
   }
 
+  detachEventListeners() {
+    this.eventListeners.forEach((entry) => {
+      const [target, event, listener] = entry;
+      target.removeListener(event, listener);
+    });
+  }
+
   dispose() {
+    this.detachEventListeners();
+    this.eventListeners = [];
+
     this.geometry.dispose();
     this.mesh.geometry.dispose();
 

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -418,6 +418,7 @@ class M2 extends THREE.Group {
     this.createVertexColorAnimations(vertexColorAnimations);
   }
 
+  // TODO: Add support for rotation and scaling in UV animations.
   createUVAnimations(uvAnimationDefs) {
     if (uvAnimationDefs.length === 0) {
       return;
@@ -432,7 +433,7 @@ class M2 extends THREE.Group {
         matrix: new THREE.Matrix4()
       };
 
-      const { translation, rotation, scaling } = uvAnimationDef;
+      const { translation } = uvAnimationDef;
 
       this.animations.registerTrack({
         target: this,

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -428,7 +428,8 @@ class M2 extends THREE.Group {
       this.uvAnimationValues[index] = {
         translation: new THREE.Vector3(),
         rotation: new THREE.Quaternion(),
-        scaling: new THREE.Vector3(1, 1, 1)
+        scaling: new THREE.Vector3(1, 1, 1),
+        matrix: new THREE.Matrix4()
       };
 
       const { translation, rotation, scaling } = uvAnimationDef;

--- a/src/lib/pipeline/m2/index.js
+++ b/src/lib/pipeline/m2/index.js
@@ -220,7 +220,7 @@ class M2 extends THREE.Group {
       materialDef.blendingMode = renderFlags[renderFlagsIndex].blendingMode;
 
       // Vertex color animation block
-      if (textureUnit.colorIndex > -1) {
+      if (textureUnit.colorIndex > -1 && colors[textureUnit.colorIndex]) {
         materialDef.vertexColorAnimation = textureUnit.colorIndex;
       }
 

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -279,6 +279,10 @@ class M2Material extends THREE.ShaderMaterial {
   }
 
   registerUVAnimations(uvAnimationIndices) {
+    if (uvAnimationIndices.length === 0) {
+      return;
+    }
+
     const { animations, uvAnimationValues } = this.m2;
 
     animations.on('update', () => {
@@ -292,6 +296,10 @@ class M2Material extends THREE.ShaderMaterial {
   }
 
   registerTransparencyAnimations(transparencyAnimationIndices) {
+    if (transparencyAnimationIndices.length === 0) {
+      return;
+    }
+
     const { animations, transparencyAnimationValues } = this.m2;
 
     animations.on('update', () => {

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -281,11 +281,11 @@ class M2Material extends THREE.ShaderMaterial {
   registerUVAnimations(uvAnimationIndices) {
     const { animations, uvAnimationValues } = this.m2;
 
-    uvAnimationIndices.forEach((uvAnimationIndex, opIndex) => {
-      const target = this.uniforms.animatedUVs;
-      const source = uvAnimationValues[uvAnimationIndex];
+    animations.on('update', () => {
+      uvAnimationIndices.forEach((uvAnimationIndex, opIndex) => {
+        const target = this.uniforms.animatedUVs;
+        const source = uvAnimationValues[uvAnimationIndex];
 
-      animations.on('update', () => {
         target.value[opIndex] = source.matrix;
       });
     });
@@ -294,11 +294,11 @@ class M2Material extends THREE.ShaderMaterial {
   registerTransparencyAnimations(transparencyAnimationIndices) {
     const { animations, transparencyAnimationValues } = this.m2;
 
-    transparencyAnimationIndices.forEach((valueIndex, opIndex) => {
-      const target = this.uniforms.animatedTransparencies;
-      const source = transparencyAnimationValues;
+    animations.on('update', () => {
+      transparencyAnimationIndices.forEach((valueIndex, opIndex) => {
+        const target = this.uniforms.animatedTransparencies;
+        const source = transparencyAnimationValues;
 
-      animations.on('update', () => {
         target.value[opIndex] = source[valueIndex];
       });
     });

--- a/src/lib/pipeline/m2/material/shader.frag
+++ b/src/lib/pipeline/m2/material/shader.frag
@@ -3,15 +3,14 @@ uniform int fragmentShaderMode;
 uniform int textureCount;
 uniform sampler2D textures[4];
 
-varying vec2 texture1Coord;
-varying vec2 texture2Coord;
+varying vec2 uv1;
+varying vec2 uv2;
 
 varying float cameraDistance;
 
 varying vec3 vertexWorldNormal;
 
-varying vec4 vertexColor;
-
+varying vec4 animatedVertexColor;
 uniform float animatedTransparencies[4];
 
 uniform float alphaKey;
@@ -35,7 +34,7 @@ float saturate(float value) {
   return result;
 }
 
-vec4 fragCombinersWotlkSingle(sampler2D texture1, vec2 uv1) {
+vec4 fragCombinersWrath1Pass(sampler2D texture1, vec2 uv1) {
   vec4 texture1Color = texture2D(texture1, uv1);
 
   if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
@@ -48,7 +47,7 @@ vec4 fragCombinersWotlkSingle(sampler2D texture1, vec2 uv1) {
   c1.a *= animatedTransparencies[0];
 
   // Blend with vertex color
-  c1.rgb *= (vertexColor.rgb * vertexColor.a);
+  c1.rgb *= (animatedVertexColor.rgb * animatedVertexColor.a);
 
   // Restore full color intensity after blending with vertexColor
   c1.rgb *= 2.0;
@@ -58,7 +57,7 @@ vec4 fragCombinersWotlkSingle(sampler2D texture1, vec2 uv1) {
   return outputColor;
 }
 
-vec4 fragCombinersWotlkMulti2(sampler2D texture1, vec2 uv1, sampler2D texture2, vec2 uv2) {
+vec4 fragCombinersWrath2Pass(sampler2D texture1, vec2 uv1, sampler2D texture2, vec2 uv2) {
   vec4 texture1Color = texture2D(texture1, uv1);
   vec4 texture2Color = texture2D(texture2, uv2);
 
@@ -77,59 +76,7 @@ vec4 fragCombinersWotlkMulti2(sampler2D texture1, vec2 uv1, sampler2D texture2, 
   c1.a *= c2.a;
 
   // Blend with vertex color
-  c1.rgb *= (vertexColor.rgb * vertexColor.a);
-
-  // Restore full color intensity after blending with vertexColor
-  c1.rgb *= 2.0;
-
-  vec4 outputColor = c1;
-
-  return outputColor;
-}
-
-vec4 fragCombinersOpaque(sampler2D texture1, vec2 uv1) {
-  vec4 texture1Color = texture2D(texture1, uv1);
-
-  if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
-    discard;
-  }
-
-  vec4 c1 = texture1Color;
-
-  // Apply animated transparency (defaults to 1.0)
-  c1.a *= animatedTransparencies[0];
-
-  // Blend with vertex color
-  c1.rgb *= (vertexColor.rgb * vertexColor.a);
-
-  // Restore full color intensity after blending with vertexColor
-  c1.rgb *= 2.0;
-
-  vec4 outputColor = c1;
-
-  return outputColor;
-}
-
-vec4 fragCombinersOpaqueAlpha(sampler2D texture1, vec2 uv1, sampler2D texture2, vec2 uv2) {
-  vec4 texture1Color = texture2D(texture1, uv1);
-  vec4 texture2Color = texture2D(texture2, uv2);
-
-  if (alphaKey == 1.0 && texture1Color.a <= 0.5) {
-    discard;
-  }
-
-  vec4 c1 = texture1Color;
-  vec4 c2 = texture2Color;
-
-  // Apply animated transparencies (defaults to 1.0)
-  c1.a *= animatedTransparencies[0];
-  c2.a *= animatedTransparencies[1];
-
-  c2.rgb = -c1.rgb + c2.rgb;
-  c1.rgb = c2.a * c2.rgb + c1.rgb;
-
-  // Blend with vertex color
-  c1.rgb *= (vertexColor.rgb * vertexColor.a);
+  c1.rgb *= (animatedVertexColor.rgb * animatedVertexColor.a);
 
   // Restore full color intensity after blending with vertexColor
   c1.rgb *= 2.0;
@@ -181,9 +128,6 @@ vec4 finalizeColor(vec4 color) {
 }
 
 void main() {
-  vec2 uv1 = vec2(texture1Coord);
-  vec2 uv2 = vec2(texture2Coord);
-
   vec4 color;
 
   // -1 = unknown / unhandled
@@ -192,9 +136,9 @@ void main() {
   if (fragmentShaderMode == -1) {
     color = texture2D(textures[0], uv1);
   } else if (fragmentShaderMode == 0) {
-    color = fragCombinersWotlkSingle(textures[0], uv1);
+    color = fragCombinersWrath1Pass(textures[0], uv1);
   } else if (fragmentShaderMode == 1) {
-    color = fragCombinersWotlkMulti2(textures[0], uv1, textures[1], uv2);
+    color = fragCombinersWrath2Pass(textures[0], uv1, textures[1], uv2);
   }
 
   // Apply lighting and fog.

--- a/src/lib/pipeline/m2/material/shader.vert
+++ b/src/lib/pipeline/m2/material/shader.vert
@@ -55,16 +55,16 @@ uniform float billboarded;
 #endif
 
 void main() {
-	// TODO: Use vertexShaderMode to determine coordinates
-	uv1 = vec2(uv[0], uv[1]);
-	uv2 = vec2(uv[0], uv[1]);
+  // TODO: Use vertexShaderMode to determine coordinates
+  uv1 = vec2(uv[0], uv[1]);
+  uv2 = vec2(uv[0], uv[1]);
 
-	// Apply texture animations
-	vec4 uv1a = animatedUVs[0] * vec4(uv1, 0, 1.0);
-	uv1 = uv1a.xy / uv1a.w;
+  // Apply texture animations
+  vec4 uv1a = animatedUVs[0] * vec4(uv1, 0, 1.0);
+  uv1 = uv1a.xy / uv1a.w;
 
-	vec4 uv2a = animatedUVs[1] * vec4(uv2, 0, 1.0);
-	uv2 = uv2a.xy / uv2a.w;
+  vec4 uv2a = animatedUVs[1] * vec4(uv2, 0, 1.0);
+  uv2 = uv2a.xy / uv2a.w;
 
   // TODO: Will this be needed in the fragment shader at some point?
   vec3 vertexWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;

--- a/src/lib/pipeline/m2/material/shader.vert
+++ b/src/lib/pipeline/m2/material/shader.vert
@@ -1,17 +1,18 @@
 precision highp float;
 
-varying vec2 texture1Coord;
-varying vec2 texture2Coord;
+varying vec2 uv1;
+varying vec2 uv2;
 
 varying float cameraDistance;
 
 varying vec3 vertexWorldNormal;
 
-varying vec4 vertexColor;
-uniform vec3 animatedVertexColor;
-uniform float animatedVertexAlpha;
-
+uniform vec3 animatedVertexColorRGB;
+uniform float animatedVertexColorAlpha;
 uniform float animatedTransparencies[4];
+uniform mat4 animatedUVs[4];
+
+varying vec4 animatedVertexColor;
 
 uniform float billboarded;
 
@@ -54,10 +55,16 @@ uniform float billboarded;
 #endif
 
 void main() {
-  // For some reason, V is inverted?!
-  // TODO: Use vertexShaderMode to determine coordinates
-  texture1Coord = vec2(uv[0], uv[1]);
-  texture2Coord = vec2(uv[0], uv[1]);
+	// TODO: Use vertexShaderMode to determine coordinates
+	uv1 = vec2(uv[0], uv[1]);
+	uv2 = vec2(uv[0], uv[1]);
+
+	// Apply texture animations
+	vec4 uv1a = animatedUVs[0] * vec4(uv1, 0, 1.0);
+	uv1 = uv1a.xy / uv1a.w;
+
+	vec4 uv2a = animatedUVs[1] * vec4(uv2, 0, 1.0);
+	uv2 = uv2a.xy / uv2a.w;
 
   // TODO: Will this be needed in the fragment shader at some point?
   vec3 vertexWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;
@@ -68,8 +75,8 @@ void main() {
   // TODO: Do we need to account for skinning?
   vertexWorldNormal = (modelMatrix * vec4(normal, 0.0)).xyz;
 
-  vertexColor.rgb = animatedVertexColor.rgb * 0.5;
-  vertexColor.a = animatedVertexAlpha;
+  animatedVertexColor.rgb = animatedVertexColorRGB.xyz * 0.5;
+  animatedVertexColor.a = animatedVertexColorAlpha;
 
   vec3 transformed = vec3(position);
 


### PR DESCRIPTION
At long last: support for UV, transparency, and vertex color animations in M2Material.

Witness waterfalls, lavafalls, sandfalls, and more come to life before your very eyes.

This depends on PRs #126 and #127. This should close #96, #97, and #98.

Please note that UV animations currently only cover translations. I haven't yet found any models with UV animations for rotation or scaling.