### PR TITLE
Feature: Better fog

### DIFF
--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -20,6 +20,7 @@ class M2Material extends THREE.ShaderMaterial {
       textureCount: { type: 'i', value: 0 },
       textures: { type: 'tv', value: [] },
 
+      blendingMode: { type: 'i', value: 0 },
       vertexShaderMode: { type: 'i', value: vertexShaderMode },
       fragmentShaderMode: { type: 'i', value: fragmentShaderMode },
 
@@ -128,6 +129,8 @@ class M2Material extends THREE.ShaderMaterial {
   }
 
   applyBlendingMode(blendingMode) {
+    this.uniforms.blendingMode.value = blendingMode;
+
     if (blendingMode === 1) {
       this.uniforms.alphaKey = { type: 'f', value: 1.0 };
     } else {

--- a/src/lib/pipeline/m2/material/shader.frag
+++ b/src/lib/pipeline/m2/material/shader.frag
@@ -55,6 +55,12 @@ vec4 fragCombinersWotlkSingle(sampler2D texture1, vec2 uv1) {
   // Restore full color intensity after blending with vertexColor
   c1.rgb *= 2.0;
 
+  // Force transparent pixels to fully opaque if in opaque blending mode (0). Needed to prevent
+  // transparent pixels from becoming inappropriately bright.
+  if (blendingMode == 0) {
+    c1.a = 1.0;
+  }
+
   vec4 outputColor = c1;
 
   return outputColor;
@@ -83,6 +89,12 @@ vec4 fragCombinersWotlkMulti2(sampler2D texture1, vec2 uv1, sampler2D texture2, 
 
   // Restore full color intensity after blending with vertexColor
   c1.rgb *= 2.0;
+
+  // Force transparent pixels to fully opaque if in opaque blending mode (0). Needed to prevent
+  // transparent pixels from becoming inappropriately bright.
+  if (blendingMode == 0) {
+    c1.a = 1.0;
+  }
 
   vec4 outputColor = c1;
 

--- a/src/lib/pipeline/wmo/material/shader.frag
+++ b/src/lib/pipeline/wmo/material/shader.frag
@@ -102,6 +102,12 @@ void main() {
     discard;
   }
 
+  // Force transparent pixels to fully opaque if in opaque blending mode. Needed to prevent fog
+  // from causing textures with transparent pixels to appear too bright in the distance.
+  if (blendingMode == 0 && color.a < 1.0) {
+    color.a = 1.0;
+  }
+
   if (lightModifier > 0.0) {
     if (indoor == 1) {
       color = lightIndoor(color, vertexColor, globalLight);

--- a/src/lib/pipeline/wmo/material/shader.frag
+++ b/src/lib/pipeline/wmo/material/shader.frag
@@ -98,14 +98,14 @@ void main() {
   // Base layer
   vec4 color = texture2D(textures[0], vUv);
 
-  // Knock out transparent pixels in blending mode 1
+  // Knock out transparent pixels in transparent blending mode (1).
   if (blendingMode == 1 && color.a < (10.0 / 255.0)) {
     discard;
   }
 
-  // Force transparent pixels to fully opaque if in opaque blending mode. Needed to prevent fog
-  // from causing textures with transparent pixels to appear too bright in the distance.
-  if (blendingMode == 0 && color.a < 1.0) {
+  // Force transparent pixels to fully opaque if in opaque blending mode (0). Needed to prevent
+  // transparent pixels from becoming inappropriately bright.
+  if (blendingMode == 0) {
     color.a = 1.0;
   }
 

--- a/src/lib/pipeline/wmo/material/shader.frag
+++ b/src/lib/pipeline/wmo/material/shader.frag
@@ -54,13 +54,14 @@ vec3 createGlobalLight(vec3 lightDirection, vec3 lightNormal, vec3 diffuseLight,
 
 vec4 applyFog(vec4 color) {
   float fogFactor = (fogEnd - cameraDistance) / (fogEnd - fogStart);
-  fogFactor = fogFactor * fogModifier;
-  fogFactor = clamp(fogFactor, 0.0, 1.0);
-  color.rgb = mix(fogColor.rgb, color.rgb, fogFactor);
+  fogFactor = 1.0 - clamp(fogFactor, 0.0, 1.0);
+  float fogColorFactor = fogFactor * fogModifier;
 
-  // Ensure alpha channel is gone once a sufficient distance into the fog is reached. Prevents
-  // texture artifacts from overlaying alpha values.
-  if (cameraDistance > fogEnd * 1.5) {
+  color.rgb = mix(color.rgb, fogColor.rgb, fogColorFactor);
+
+  // Ensure certain blending mode pixels become fully opaque by fog end.
+  if (cameraDistance >= fogEnd) {
+    color.rgb = fogColor.rgb;
     color.a = 1.0;
   }
 


### PR DESCRIPTION
This PR fixes various fog issues.

* Alpha transparencies in textures used in WMO materials flagged with opaque blending mode now get their alpha values forced to 1.0 prior to light and fog shading. This prevents oddities such as glowing stone textures on the Darkshire blacksmith chimney, various human stone towers, and so on. It also fixes the inappropriately bright textures in the Exodar (particularly noticeable in the entrance ramp to the Exodar).

* Similarly, M2 material textures that use alpha transparencies, but which render in the opaque blending mode, also get their alpha values forced to 1.0. This resolves overly bright textures in certain M2s, such as the burning ship at the entrance to Howling Fjord.

* All pixels now fully fade in to the fog. Perhaps because the actual game uses a different rendering technique than we do in Wowser, some extra logic beyond simply observing the unfogged flag is necessary in order to get everything to be fully obscured in the fog.