### PR TITLE
Feature: glslify loader improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pretest": "gulp rebuild",
     "reset": "gulp reset",
     "test": "istanbul test ./node_modules/mocha/bin/_mocha -- spec --recursive",
-    "web-dev": "webpack-dev-server",
+    "web-dev": "webpack-dev-server --host 0.0.0.0",
     "web-release": "webpack --optimize --progress"
   },
   "repository": "wowserhq/wowser",
@@ -67,7 +67,7 @@
     "eslint-loader": "^1.1.1",
     "eslint-plugin-react": "^3.9.0",
     "file-loader": "^0.8.4",
-    "glslify-loader": "^1.0.2",
+    "glslify-loader": "wowserhq/glslify-loader#query-opts",
     "gulp": "gulpjs/gulp.git#4.0",
     "gulp-babel": "^5.1.0",
     "gulp-cached": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pretest": "gulp rebuild",
     "reset": "gulp reset",
     "test": "istanbul test ./node_modules/mocha/bin/_mocha -- spec --recursive",
-    "web-dev": "webpack-dev-server --host 0.0.0.0",
+    "web-dev": "webpack-dev-server",
     "web-release": "webpack --optimize --progress"
   },
   "repository": "wowserhq/wowser",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react": "^3.9.0",
     "file-loader": "^0.8.4",
     "glslify-loader": "wowserhq/glslify-loader#query-opts",
+    "glslify-import": "^3.0.0",
     "gulp": "gulpjs/gulp.git#4.0",
     "gulp-babel": "^5.1.0",
     "gulp-cached": "^1.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
         exclude: /node_modules/
       },
       {
-        test: /\.(frag|vert)$/,
+        test: /\.(frag|vert|glsl)$/,
         loader: 'raw-loader!glslify-loader?transform[]=glslify-import',
         exclude: /node_modules/
       },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
       },
       {
         test: /\.(frag|vert)$/,
-        loader: 'raw-loader!glslify-loader',
+        loader: 'raw-loader!glslify-loader?transform[]=glslify-import',
         exclude: /node_modules/
       },
       {


### PR DESCRIPTION
Several nice-to-haves as we continue to expand the shader logic present in Wowser:

* Added support for ```.glsl``` extensions
* Added support for passing transforms into glslify when loading source via ```glslify-loader```
* Added support for ```glslify-import```: we can now use statements like ```#pragma glslify: import('./common.glsl')``` in GLSL source to avoid code duplication