### PR TITLE
Feature: M2 batch cleanup

### DIFF
--- a/src/lib/pipeline/m2/batch-manager.js
+++ b/src/lib/pipeline/m2/batch-manager.js
@@ -1,0 +1,137 @@
+class BatchManager {
+
+  constructor() {
+  }
+
+  createDefs(data, skinData) {
+    const defs = [];
+
+    skinData.batches.forEach((batchData) => {
+      const def = this.createDef(data, batchData);
+      defs.push(def);
+    });
+
+    return defs;
+  }
+
+  createDef(data, batchData) {
+    const def = this.stubDef();
+
+    const { textures } = data;
+    const { vertexColorAnimations, transparencyAnimations, uvAnimations } = data;
+
+    if (!batchData.textureIndices) {
+      this.resolveTextureIndices(data, batchData);
+    }
+
+    if (!batchData.uvAnimationIndices) {
+      this.resolveUVAnimationIndices(data, batchData);
+    }
+
+    const { opCount } = batchData;
+    const { textureMappingIndex, materialIndex } = batchData;
+    const { vertexColorAnimationIndex, transparencyAnimationLookup } = batchData;
+    const { textureIndices, uvAnimationIndices } = batchData;
+
+    // Batch flags
+    def.flags = batchData.flags;
+
+    // Submesh index and batch layer
+    def.submeshIndex = batchData.submeshIndex;
+    def.layer = batchData.layer;
+
+    // Op count and shader ID
+    def.opCount = batchData.opCount;
+    def.shaderID = batchData.shaderID;
+
+    // Texture mapping
+    // -1 => Env; 0 => T1; 1 => T2
+    if (textureMappingIndex >= 0) {
+      const textureMapping = data.textureMappings[textureMappingIndex];
+      def.textureMapping = textureMapping;
+    }
+
+    // Material (render flags and blending mode)
+    const material = data.materials[materialIndex];
+    def.renderFlags = material.renderFlags;
+    def.blendingMode = material.blendingMode;
+
+    // Vertex color animation block
+    if (vertexColorAnimationIndex > -1 && vertexColorAnimations[vertexColorAnimationIndex]) {
+      const vertexColorAnimation = vertexColorAnimations[vertexColorAnimationIndex];
+      def.vertexColorAnimation = vertexColorAnimation;
+      def.vertexColorAnimationIndex = vertexColorAnimationIndex;
+    }
+
+    // Transparency animation block
+    // TODO: Do we load multiple values based on opCount?
+    const transparencyAnimationIndex = data.transparencyAnimationLookups[transparencyAnimationLookup];
+    if (transparencyAnimationIndex > -1 && transparencyAnimations[transparencyAnimationIndex]) {
+      const transparencyAnimation = transparencyAnimations[transparencyAnimationIndex];
+      def.transparencyAnimation = transparencyAnimation;
+      def.transparencyAnimationIndex = transparencyAnimationIndex;
+    }
+
+    for (let opIndex = 0; opIndex < def.opCount; ++opIndex) {
+      // Texture
+      const textureIndex = textureIndices[opIndex];
+      const texture = textures[textureIndex];
+      if (texture) {
+        def.textures[opIndex] = texture;
+        def.textureIndices[opIndex] = textureIndex;
+      }
+
+      // UV animation block
+      const uvAnimationIndex = uvAnimationIndices[opIndex];
+      const uvAnimation = uvAnimations[uvAnimationIndex];
+      if (uvAnimation) {
+        def.uvAnimations[opIndex] = uvAnimation;
+        def.uvAnimationIndices[opIndex] = uvAnimationIndex;
+      }
+    }
+
+    return def;
+  }
+
+  resolveTextureIndices(data, batchData) {
+    batchData.textureIndices = [];
+
+    for (let opIndex = 0; opIndex < batchData.opCount; opIndex++) {
+      const textureIndex = data.textureLookups[batchData.textureLookup + opIndex];
+      batchData.textureIndices.push(textureIndex);
+    }
+  }
+
+  resolveUVAnimationIndices(data, batchData) {
+    batchData.uvAnimationIndices = [];
+
+    for (let opIndex = 0; opIndex < batchData.opCount; opIndex++) {
+      const uvAnimationIndex = data.uvAnimationLookups[batchData.uvAnimationLookup + opIndex];
+      batchData.uvAnimationIndices.push(uvAnimationIndex);
+    }
+  }
+
+  stubDef() {
+    const def = {
+      flags: null,
+      shaderID: null,
+      opCount: null,
+      textureMapping: null,
+      renderFlags: null,
+      blendingMode: null,
+      textures: [],
+      textureIndices: [],
+      uvAnimations: [],
+      uvAnimationIndices: [],
+      transparencyAnimation: null,
+      transparencyAnimationIndex: null,
+      vertexColorAnimation: null,
+      vertexColorAnimationIndex: null
+    };
+
+    return def;
+  }
+
+}
+
+export default BatchManager;

--- a/src/lib/pipeline/m2/material/index.js
+++ b/src/lib/pipeline/m2/material/index.js
@@ -34,8 +34,8 @@ class M2Material extends THREE.ShaderMaterial {
       animatedVertexColorRGB: { type: 'v3', value: new THREE.Vector3(1.0, 1.0, 1.0) },
       animatedVertexColorAlpha: { type: 'f', value: 1.0 },
 
-      // Animated transparencies
-      animatedTransparencies: { type: '1fv', value: [1.0, 1.0, 1.0, 1.0] },
+      // Animated transparency
+      animatedTransparency: { type: 'f', value: 1.0 },
 
       // Animated texture coordinate transform matrices
       animatedUVs: {
@@ -273,11 +273,11 @@ class M2Material extends THREE.ShaderMaterial {
   }
 
   registerAnimations(def) {
-    const { uvAnimations, transparencyAnimations, vertexColorAnimation } = def;
+    const { uvAnimationIndices, transparencyAnimationIndex, vertexColorAnimationIndex } = def;
 
-    this.registerUVAnimations(uvAnimations);
-    this.registerTransparencyAnimations(transparencyAnimations);
-    this.registerVertexColorAnimation(vertexColorAnimation);
+    this.registerUVAnimations(uvAnimationIndices);
+    this.registerTransparencyAnimation(transparencyAnimationIndex);
+    this.registerVertexColorAnimation(vertexColorAnimationIndex);
   }
 
   registerUVAnimations(uvAnimationIndices) {
@@ -301,20 +301,19 @@ class M2Material extends THREE.ShaderMaterial {
     this.eventListeners.push([animations, 'update', updater]);
   }
 
-  registerTransparencyAnimations(transparencyAnimationIndices) {
-    if (transparencyAnimationIndices.length === 0) {
+  registerTransparencyAnimation(transparencyAnimationIndex) {
+    if (transparencyAnimationIndex === null || transparencyAnimationIndex === -1) {
       return;
     }
 
     const { animations, transparencyAnimationValues } = this.m2;
 
-    const updater = () => {
-      transparencyAnimationIndices.forEach((valueIndex, opIndex) => {
-        const target = this.uniforms.animatedTransparencies;
-        const source = transparencyAnimationValues;
+    const target = this.uniforms.animatedTransparency;
+    const source = transparencyAnimationValues;
+    const valueIndex = transparencyAnimationIndex;
 
-        target.value[opIndex] = source[valueIndex];
-      });
+    const updater = () => {
+      target.value = source[valueIndex];
     };
 
     animations.on('update', updater);

--- a/src/lib/pipeline/m2/material/shader.frag
+++ b/src/lib/pipeline/m2/material/shader.frag
@@ -11,7 +11,7 @@ varying float cameraDistance;
 varying vec3 vertexWorldNormal;
 
 varying vec4 animatedVertexColor;
-uniform float animatedTransparencies[4];
+uniform float animatedTransparency;
 
 uniform float alphaKey;
 
@@ -46,7 +46,7 @@ vec4 fragCombinersWrath1Pass(sampler2D texture1, vec2 uv1) {
   vec4 c1 = texture1Color;
 
   // Apply animated transparency (defaults to 1.0)
-  c1.a *= animatedTransparencies[0];
+  c1.a *= animatedTransparency;
 
   // Blend with vertex color
   c1.rgb *= (animatedVertexColor.rgb * animatedVertexColor.a);
@@ -76,9 +76,8 @@ vec4 fragCombinersWrath2Pass(sampler2D texture1, vec2 uv1, sampler2D texture2, v
   vec4 c1 = texture1Color;
   vec4 c2 = texture2Color;
 
-  // Apply animated transparencies (defaults to 1.0)
-  c1.a *= animatedTransparencies[0];
-  c2.a *= animatedTransparencies[1];
+  // Apply animated transparency (defaults to 1.0)
+  c1.a *= animatedTransparency;
 
   // Blend texture alphas
   c1.a *= c2.a;

--- a/src/lib/pipeline/m2/material/shader.vert
+++ b/src/lib/pipeline/m2/material/shader.vert
@@ -9,7 +9,7 @@ varying vec3 vertexWorldNormal;
 
 uniform vec3 animatedVertexColorRGB;
 uniform float animatedVertexColorAlpha;
-uniform float animatedTransparencies[4];
+uniform float animatedTransparency;
 uniform mat4 animatedUVs[4];
 
 varying vec4 animatedVertexColor;

--- a/src/lib/pipeline/m2/submesh.js
+++ b/src/lib/pipeline/m2/submesh.js
@@ -14,51 +14,46 @@ class Submesh extends THREE.Group {
 
     if (this.useSkinning) {
       // Preserve the rootBone for the submesh such that its skin property can be assigned to the
-      // first child texture unit mesh.
+      // first child batch mesh.
       this.rootBone = opts.rootBone;
       this.billboarded = opts.rootBone.userData.billboarded;
 
-      // Preserve the skeleton for use in applying texture units.
+      // Preserve the skeleton for use in applying batches.
       this.skeleton = opts.skeleton;
     }
 
-    // Preserve the geometry for use in applying texture units.
+    // Preserve the geometry for use in applying batches.
     this.geometry = opts.geometry;
   }
 
-  // Submeshes get one mesh per texture unit, which allows them to effectively simulate multiple
-  // render passes. Texture unit mesh rendering order should be handled properly by the three.js
+  // Submeshes get one mesh per batch, which allows them to effectively simulate multiple
+  // render passes. Batch mesh rendering order should be handled properly by the three.js
   // renderer.
-  //
-  // For clarity's sake, a texture unit is represented in three.js by a 1:1 coupling of a
-  // SkinnedMesh and a ShaderMaterial. We call them texture units to maintain consistency with
-  // other World of Warcraft projects.
-  //
-  applyTextureUnits(textureUnits) {
-    this.clearTextureUnits();
+  applyBatches(batches) {
+    this.clearBatches();
 
-    const tuLen = textureUnits.length;
-    for (let tuIndex = 0; tuIndex < tuLen; ++tuIndex) {
-      const tuMaterial = textureUnits[tuIndex];
+    const batchLen = batches.length;
+    for (let batchIndex = 0; batchIndex < batchLen; ++batchIndex) {
+      const batchMaterial = batches[batchIndex];
 
       // If the submesh is billboarded, flag the material as billboarded.
       if (this.billboarded) {
-        tuMaterial.enableBillboarding();
+        batchMaterial.enableBillboarding();
       }
 
-      let tuMesh;
+      let batchMesh;
 
       // Only use a skinned mesh if the submesh uses skinning.
       if (this.useSkinning) {
-        tuMesh = new THREE.SkinnedMesh(this.geometry, tuMaterial);
-        tuMesh.bind(this.skeleton);
+        batchMesh = new THREE.SkinnedMesh(this.geometry, batchMaterial);
+        batchMesh.bind(this.skeleton);
       } else {
-        tuMesh = new THREE.Mesh(this.geometry, tuMaterial);
+        batchMesh = new THREE.Mesh(this.geometry, batchMaterial);
       }
 
-      tuMesh.matrixAutoUpdate = this.matrixAutoUpdate;
+      batchMesh.matrixAutoUpdate = this.matrixAutoUpdate;
 
-      this.add(tuMesh);
+      this.add(batchMesh);
     }
 
     if (this.useSkinning) {
@@ -66,8 +61,8 @@ class Submesh extends THREE.Group {
     }
   }
 
-  // Remove any existing texture unit child meshes.
-  clearTextureUnits() {
+  // Remove any existing child batch meshes.
+  clearBatches() {
     const childrenLength = this.children.length;
     for (let childIndex = 0; childIndex < childrenLength; ++childIndex) {
       const child = this.children[childIndex];
@@ -75,13 +70,13 @@ class Submesh extends THREE.Group {
     }
 
     if (this.useSkinning) {
-      // If all texture unit meshes are cleared, there is no longer a skin to associate with the
+      // If all batch meshes are cleared, there is no longer a skin to associate with the
       // root bone.
       this.rootBone.skin = null;
     }
   }
 
-  // Update all existing texture unit mesh materials to point to the new skins (textures).
+  // Update all existing batch mesh materials to point to the new skins (textures).
   set displayInfo(displayInfo) {
     const { path } = displayInfo.modelData;
 


### PR DESCRIPTION
These changes are being done in preparation for the more significant changes relating to proper shaders for Wrath of the Lich King content.

#### Changes

* Renamed texture units to batches (a more conventional term, and one that matches debug strings in the client)

* Synced attribute name changes in parsed M2 and skin data against Blizzardry

* Migrated batch definition logic into a dedicated batch manager to reduce clutter in the root M2 class

* Switched to single transparency animation per batch based on observations from disassembly