### PR TITLE
Have Express set correct mime types

### DIFF
--- a/src/lib/server/pipeline/index.js
+++ b/src/lib/server/pipeline/index.js
@@ -50,7 +50,7 @@ class Pipeline {
       const png = new PNG({ width: mipmap.width, height: mipmap.height });
       png.data = mipmap.rgba;
 
-      res.set('Content-Type', 'image/png');
+      res.type('image/png');
       png.pack().pipe(res);
     });
   }
@@ -87,6 +87,7 @@ class Pipeline {
   }
 
   serve(req, res) {
+    res.type(req.resource.name);
     res.send(req.resource.data);
   }
 


### PR DESCRIPTION
Express' `Response#type`-method will set the correct content type based on extension.

Among other things, this allows audio files to be played inline rather than prompting a download:

![screen shot 2016-06-11 at 18 27 00](https://cloud.githubusercontent.com/assets/378235/15986245/554a2a8e-3003-11e6-9ad1-512c327254de.png)

