### PR TITLE
Add links to pipeline results

### DIFF
--- a/src/lib/server/pipeline/index.js
+++ b/src/lib/server/pipeline/index.js
@@ -83,7 +83,17 @@ class Pipeline {
   }
 
   find(req, res) {
-    res.send(this.archive.files.find(req.params.query));
+    const results = this.archive.files.find(req.params.query).map((result) => {
+      const path = `${req.baseUrl}/${encodeURI(result.filename)}`;
+      const link = `${req.protocol}://${req.headers.host}${path}`;
+      return {
+        filename: result.filename,
+        name: result.name,
+        size: result.fileSize,
+        link: link
+      };
+    });
+    res.send(results);
   }
 
   serve(req, res) {


### PR DESCRIPTION
This filters away a bunch of internal properties from the pipeline results and adds a `link`-property.

Depending on the JSON viewing capabilities of the browser, it allows easy navigation between files in the game archives:

![screen shot 2016-06-11 at 18 24 29](https://cloud.githubusercontent.com/assets/378235/15986263/d3891874-3003-11e6-9535-570388c10ab3.png)


