### PR TITLE
Reference second tech demo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ World of Warcraft in the browser using JavaScript and WebGL.
 
 Licensed under the **MIT** license, see LICENSE for more information.
 
-[![See Wowser tech demo](https://user-images.githubusercontent.com/378235/27263611-9c2490cc-546d-11e7-855a-048b1e86a1ea.jpg)](https://www.youtube.com/watch?v=8QFY_3uM1iw)
+[![See Wowser tech demo](https://user-images.githubusercontent.com/378235/27762818-800fd91c-5e79-11e7-8301-733d736dd065.jpg)](https://www.youtube.com/watch?v=BrnbANSwC4I)
 
 ## Background
 


### PR DESCRIPTION
@fallenoak uploaded a new tech demo quite a while ago. This PR updates the thumbnail and video reference in the README.

The new README can be previewed here: https://github.com/wowserhq/wowser/blob/37e91de1a3f7effa64d8ff6e9b90bcbfc1de62ba/README.md