### PR TITLE
feature/fix-gulp-on-windows-10

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "file-loader": "^0.9.0",
     "glslify-loader": "wowserhq/glslify-loader#query-opts",
     "glslify-import": "^3.0.0",
-    "gulp": "gulpjs/gulp.git#4.0",
+    "gulp": "4.0",
     "gulp-babel": "^6.1.0",
     "gulp-cached": "^1.1.0",
     "gulp-mocha": "2.2.0",


### PR DESCRIPTION
Edit package.json file to use version 4.0 of gulp.